### PR TITLE
Resolve warning in MotionBlur shader

### DIFF
--- a/PostProcessing/Resources/Shaders/MotionBlur.cginc
+++ b/PostProcessing/Resources/Shaders/MotionBlur.cginc
@@ -383,6 +383,7 @@ VaryingsDefault VertFrameCompress(AttributesDefault v)
 {
     VaryingsDefault o;
     o.pos = v.vertex * float4(2.0, 2.0, 0.0, 0.0) + float4(0.0, 0.0, 0.0, 1.0);
+    o.uvSPR = 0;
 #if UNITY_UV_STARTS_AT_TOP
     o.uv = v.texcoord * float2(1.0, -1.0) + float2(0.0, 1.0);
 #else


### PR DESCRIPTION
When I compiled the shaders the MotionBlur shader issued the following warning:

```
'Hidden/Post FX/Motion Blur': variable 'o' used without having been completely initialized at Assets/PostProcessing/Resources/Shaders/MotionBlur.cginc(391) (on d3d9)
```

After reviewing this I discovered that the uvSPR member of the instantiated VaryingsDefault 
struct was not initialized; causing this error to occur. By initializing this member to 0 it provides
a valid initial value and as such will resolve the aforementioned warning.