### PR TITLE
Implement support for ACES 1.0.3

### DIFF
--- a/PostProcessing/Resources/Shaders/Tonemapping.cginc
+++ b/PostProcessing/Resources/Shaders/Tonemapping.cginc
@@ -43,7 +43,7 @@ half3 NeutralTonemap(half3 x, half4 params1, half4 params2)
 }
 
 //
-// Filmic tonemapping (pre-exposed ACES approximation, unless TONEMAPPING_USE_FULL_ACES is set to 1)
+// Filmic tonemapping (ACES fitting, unless TONEMAPPING_USE_FULL_ACES is set to 1)
 // Input is ACES2065-1 (AP0 w/ linear encoding)
 //
 half3 FilmicTonemap(half3 aces)
@@ -81,25 +81,38 @@ half3 FilmicTonemap(half3 aces)
     //acescg = mul(RRT_SAT_MAT, acescg);
     acescg = lerp(dot(acescg, AP1_RGB2Y).xxx, acescg, RRT_SAT_FACTOR.xxx);
 
-    // Quick'n'dirty approximation of the ACES tonemapper - pre-exposed RRT(ODT())
-    // Adapted from https://knarkowicz.wordpress.com/2016/01/06/aces-filmic-tone-mapping-curve/ to
-    // fit our range & exposure.
-    const half a = 2.5;
-    const half b = 0.03;
-    const half c = 2.49;
-    const half d = 0.6;
-    const half e = 0.2;
+    // Luminance fitting of *RRT.a1.0.3 + ODT.Academy.RGBmonitor_100nits_dim.a1.0.3*.
+    // https://github.com/colour-science/colour-unity/blob/master/Assets/Colour/Notebooks/CIECAM02_Unity.ipynb
+    // RMSE: 0.0012846272106
+	const half a = 278.5085;
+	const half b = 10.7772;
+	const half c = 293.6045;
+	const half d = 88.7122;
+	const half e = 80.6889;
     half3 x = acescg;
-    half3 color = (x * (a * x + b)) / (x * (c * x + d) + e);
+    half3 rgbPost = (x * (a * x + b)) / (x * (c * x + d) + e);
+
+    // Scale luminance to linear code value
+    // half3 linearCV = Y_2_linCV(rgbPost, CINEMA_WHITE, CINEMA_BLACK);
 
     // Apply gamma adjustment to compensate for dim surround
-    color = darkSurround_to_dimSurround(color);
+    half3 linearCV = darkSurround_to_dimSurround(rgbPost);
 
     // Apply desaturation to compensate for luminance difference
-    //color = mul(ODT_SAT_MAT, color);
-    color = lerp(dot(color, AP1_RGB2Y).xxx, color, ODT_SAT_FACTOR.xxx);
+    //linearCV = mul(ODT_SAT_MAT, color);
+    linearCV = lerp(dot(linearCV, AP1_RGB2Y).xxx, linearCV, ODT_SAT_FACTOR.xxx);
 
-    return ACEScg_to_unity(color);
+    // Convert to display primary encoding
+    // Rendering space RGB to XYZ
+    half3 XYZ = mul(AP1_2_XYZ_MAT, linearCV);
+
+    // Apply CAT from ACES white point to assumed observer adapted white point
+    XYZ = mul(D60_2_D65_CAT, XYZ);
+
+    // CIE XYZ to display primaries
+    linearCV = mul(XYZ_2_REC709_MAT, XYZ);
+
+    return linearCV;
 
 #endif
 }

--- a/PostProcessing/Resources/Shaders/Tonemapping.cginc
+++ b/PostProcessing/Resources/Shaders/Tonemapping.cginc
@@ -50,8 +50,8 @@ half3 FilmicTonemap(half3 aces)
 {
 #if TONEMAPPING_USE_FULL_ACES
 
-    half3 oces = RRT(aces * 1.8);
-    half3 odt = ODT_RGBMonitor(oces);
+    half3 oces = RRT(aces);
+    half3 odt = ODT_RGBmonitor_100nits_dim(oces);
     return odt;
 
 #else


### PR DESCRIPTION
Hi,

# Fixes & Features

This PR addresses and implements a few things:

- The current fitting has been updated to match the Luminance output of *RRT.a1.0.3 + ODT.Academy.RGBmonitor_100nits_dim.a1.0.3*, no pre-exposure because this is not what the ACES RRT look is meant to be. The fitting code is available and can be reproduced as needed. I can also make a dedicated notebook for it and extract the relevant portion from the current one: https://github.com/colour-science/colour-unity/blob/master/Assets/Colour/Notebooks/CIECAM02_Unity.ipynb
- It implements support for ACES 1.0.3:
  - The ODT names have been updated to match the ACES CTL codebase in order to avoid confusion, it will make future updates easier, I reckon that the `ACES.cginc` should include the tag / release version of ACES. The changes of this PR are based on https://github.com/ampas/aces-dev/releases/tag/v1.0.3
  - Various ODTs for D65 whitepoint adapted observer were added. They should be better as more neutral for typical contexts where Unity applications are being created, i.e. video games development on sRGB monitors matching loosely IEC 61966-2-1:1999 specification. The currently implemented ODTs are assuming that the observer is adapted to D60, thus the output images are reddish / yellowish:
    - RGBmonitor_100nits_dim.a1.0.3
    - Rec709_100nits_dim.a1.0.3
- Various TODOs for missing features and NOTEs explaining certain behaviour induced by Unity defaults were added.

# Issues & Future Work
- There is a slight luminance shift between the full ACES path and the fitting path, I'm not sure what is the source of it which leads me to the following point:
- The current whole ACES implementation should be reviewed against the current AMPAS 1.0.3 release to see if there is anything missing, which underline the importance of referencing the ACES release tag.
- Considering the current behaviour of Unity as far as sRGB encoding the framebuffer, which is really a bad thing, I already discussed about it with Seb Lagarde on your end, I would argue that for now the ODTs should be maybe decoded with sRGB EOTF if it does not introduce banding or quantisation issues.

# Output & References

## OpenColorIO - Ground Truth

**Reference - sRGB**
![image](https://cloud.githubusercontent.com/assets/99779/19415782/e8398596-93d7-11e6-8ed7-ff388a5ec320.png)

**Reference - ACES - ODT.Academy.RGBmonitor_100nits_dim.a1.0.3**
![image](https://cloud.githubusercontent.com/assets/99779/19415783/0569165e-93d8-11e6-97f9-27b7ee611769.png)

**Reference - Luminance Fitting - ACES - ODT.Academy.RGBmonitor_100nits_dim.a1.0.3**
![image](https://cloud.githubusercontent.com/assets/99779/19415797/5e27c3da-93d8-11e6-8a48-2027e7e4d418.png)

## Unity - PR

**Unity - PR - ACES - ODT.Academy.RGBmonitor_100nits_dim.a1.0.3**
![image](https://cloud.githubusercontent.com/assets/99779/19415799/a3ff2d1c-93d8-11e6-8384-d92a46e988e9.png)

**Unity - PR - Fitting - ACES - ODT.Academy.RGBmonitor_100nits_dim.a1.0.3**
![image](https://cloud.githubusercontent.com/assets/99779/19415800/afe952a6-93d8-11e6-970c-5fb6165530e2.png)

## Unity - Master

**Unity - Master - ACES - ODT.Academy.RGBmonitor_D60_sim_100nits_dim.???**
![image](https://cloud.githubusercontent.com/assets/99779/19415792/3c8459b4-93d8-11e6-809d-c15f7b286d46.png)

**Unity - Master - Fitting - ACES - ???**
![image](https://cloud.githubusercontent.com/assets/99779/19415796/555a1050-93d8-11e6-96d9-9cd41ac05a84.png)

Voila :)
