### PR TITLE
The DOF prefilter pass needs a gamma variant.

### DIFF
--- a/PostProcessing/Resources/Shaders/DepthOfField.shader
+++ b/PostProcessing/Resources/Shaders/DepthOfField.shader
@@ -18,6 +18,7 @@ Shader "Hidden/Post FX/Depth Of Field"
         Pass
         {
             CGPROGRAM
+                #pragma multi_compile __ UNITY_COLORSPACE_GAMMA
                 #pragma vertex VertDOF
                 #pragma fragment FragPrefilter
                 #include "DepthOfField.cginc"


### PR DESCRIPTION
The entire screen is bleached out in gamma lighting. This can be fixed just by adding a multi compilation directive into the DOF prefilter pass block.