### PR TITLE
Added a default depth texture mode so users can set their own

### DIFF
--- a/PostProcessing/Editor/PostProcessingInspector.cs
+++ b/PostProcessing/Editor/PostProcessingInspector.cs
@@ -162,6 +162,8 @@ namespace UnityEditor.PostProcessing
             if (!m_ConcreteTarget.debugViews.IsModeActive(BuiltinDebugViewsModel.Mode.None))
                 EditorGUILayout.HelpBox("A debug view is currently enabled. Changes done to an effect might not be visible.", MessageType.Info);
 
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("DefaultDepthTextureMode"));
+
             foreach (var editor in m_CustomEditors)
             {
                 EditorGUI.BeginChangeCheck();

--- a/PostProcessing/Runtime/PostProcessingBehaviour.cs
+++ b/PostProcessing/Runtime/PostProcessingBehaviour.cs
@@ -134,7 +134,7 @@ namespace UnityEngine.PostProcessing
 
             // Find out which camera flags are needed before rendering begins
             // Note that motion vectors will only be available one frame after being enabled
-            var flags = DepthTextureMode.None;
+            var flags = profile.DefaultDepthTextureMode;
             foreach (var component in m_Components)
             {
                 if (component.active)

--- a/PostProcessing/Runtime/PostProcessingProfile.cs
+++ b/PostProcessing/Runtime/PostProcessingProfile.cs
@@ -4,7 +4,9 @@ namespace UnityEngine.PostProcessing
 {
     public class PostProcessingProfile : ScriptableObject
     {
-        #pragma warning disable 0169 // "field x is never used"
+#pragma warning disable 0169 // "field x is never used"
+
+        public DepthTextureMode DefaultDepthTextureMode = DepthTextureMode.None;
 
         public BuiltinDebugViewsModel debugViews = new BuiltinDebugViewsModel();
         public AntialiasingModel antialiasing = new AntialiasingModel();


### PR DESCRIPTION
At this moment the postprocessing stack always overwrites the [depthTextureMode](https://docs.unity3d.com/ScriptReference/Camera-depthTextureMode.html) of the camera, this can cause issues with other, user-defined, effects. Especially when all PostProcessingComponents are disabled its always being set to None.

This pull request allows the user to set a preferred mode per profile.

