### PR TITLE
Fix for issue #26 (reopened)

### DIFF
--- a/PostProcessing/Resources/Shaders/DepthOfField.shader
+++ b/PostProcessing/Resources/Shaders/DepthOfField.shader
@@ -25,7 +25,18 @@ Shader "Hidden/Post FX/Depth Of Field"
             ENDCG
         }
 
-        // (1-4) Bokeh filter with disk-shaped kernels
+        // (1) Pass 0 + temporal antialiasing
+        Pass
+        {
+            CGPROGRAM
+                #pragma vertex VertDOF
+                #pragma fragment FragPrefilter
+                #define PREFILTER_TAA
+                #include "DepthOfField.cginc"
+            ENDCG
+        }
+
+        // (2-5) Bokeh filter with disk-shaped kernels
         Pass
         {
             CGPROGRAM
@@ -66,27 +77,7 @@ Shader "Hidden/Post FX/Depth Of Field"
             ENDCG
         }
 
-        // (5) CoC antialiasing
-        Pass
-        {
-            CGPROGRAM
-                #pragma vertex VertDOF
-                #pragma fragment FragAntialiasCoC
-                #include "DepthOfField.cginc"
-            ENDCG
-        }
-
-        // (6) CoC history clearing
-        Pass
-        {
-            CGPROGRAM
-                #pragma vertex VertDOF
-                #pragma fragment FragClearCoCHistory
-                #include "DepthOfField.cginc"
-            ENDCG
-        }
-
-        // (7) Postfilter blur
+        // (6) Postfilter blur
         Pass
         {
             CGPROGRAM

--- a/PostProcessing/Runtime/Components/DepthOfFieldComponent.cs
+++ b/PostProcessing/Runtime/Components/DepthOfFieldComponent.cs
@@ -16,6 +16,7 @@ namespace UnityEngine.PostProcessing
             internal static readonly int _RcpAspect          = Shader.PropertyToID("_RcpAspect");
             internal static readonly int _MainTex            = Shader.PropertyToID("_MainTex");
             internal static readonly int _HistoryCoC         = Shader.PropertyToID("_HistoryCoC");
+            internal static readonly int _HistoryWeight      = Shader.PropertyToID("_HistoryWeight");
 	        internal static readonly int _DepthOfFieldParams = Shader.PropertyToID("_DepthOfFieldParams");
         }
 
@@ -92,43 +93,36 @@ namespace UnityEngine.PostProcessing
             source.filterMode = FilterMode.Point;
 
             // Pass #1 - Downsampling, prefiltering and CoC calculation
-            Graphics.Blit(source, rt1, material, 0);
-
-            // Pass #2 - CoC Antialiasing
-            var pass = rt1;
-            if (antialiasCoC)
+            if (!antialiasCoC)
             {
-                pass = context.renderTextureFactory.Get(context.width / 2, context.height / 2, 0, RenderTextureFormat.ARGBHalf);
-
-                if (m_CoCHistory == null || !m_CoCHistory.IsCreated() || m_CoCHistory.width != context.width / 2 || m_CoCHistory.height != context.height / 2)
-                {
-                    m_CoCHistory = RenderTexture.GetTemporary(context.width / 2, context.height / 2, 0, RenderTextureFormat.RHalf);
-                    m_CoCHistory.filterMode = FilterMode.Point;
-                    m_CoCHistory.name = "CoC History";
-                    Graphics.Blit(rt1, m_CoCHistory, material, 6);
-                }
+                Graphics.Blit(source, rt1, material, 0);
+            }
+            else
+            {
+                var initial = m_CoCHistory == null || !m_CoCHistory.IsCreated() || m_CoCHistory.width != context.width / 2 || m_CoCHistory.height != context.height / 2;
 
                 var tempCoCHistory = RenderTexture.GetTemporary(context.width / 2, context.height / 2, 0, RenderTextureFormat.RHalf);
                 tempCoCHistory.filterMode = FilterMode.Point;
                 tempCoCHistory.name = "CoC History";
 
-                m_MRT[0] = pass.colorBuffer;
+                m_MRT[0] = rt1.colorBuffer;
                 m_MRT[1] = tempCoCHistory.colorBuffer;
-                material.SetTexture(Uniforms._MainTex, rt1);
+                material.SetTexture(Uniforms._MainTex, source);
                 material.SetTexture(Uniforms._HistoryCoC, m_CoCHistory);
+                material.SetFloat(Uniforms._HistoryWeight, initial ? 0 : 0.5f);
                 Graphics.SetRenderTarget(m_MRT, rt1.depthBuffer);
-                GraphicsUtils.Blit(material, 5);
+                GraphicsUtils.Blit(material, 1);
 
                 RenderTexture.ReleaseTemporary(m_CoCHistory);
                 m_CoCHistory = tempCoCHistory;
             }
 
-            // Pass #3 - Bokeh simulation
+            // Pass #2 - Bokeh simulation
             var rt2 = context.renderTextureFactory.Get(context.width / 2, context.height / 2, 0, RenderTextureFormat.ARGBHalf);
-            Graphics.Blit(pass, rt2, material, 1 + (int)settings.kernelSize);
+            Graphics.Blit(rt1, rt2, material, 2 + (int)settings.kernelSize);
 
-            // Pass #4 - Postfilter blur
-            Graphics.Blit(rt2, rt1, material, 7);
+            // Pass #3 - Postfilter blur
+            Graphics.Blit(rt2, rt1, material, 6);
 
             if (context.profile.debugViews.IsModeActive(DebugMode.FocusPlane))
             {
@@ -142,9 +136,7 @@ namespace UnityEngine.PostProcessing
                 uberMaterial.EnableKeyword("DEPTH_OF_FIELD");
             }
 
-            if (antialiasCoC)
-                context.renderTextureFactory.Release(pass);
-
+            context.renderTextureFactory.Release(rt1);
             context.renderTextureFactory.Release(rt2);
             source.filterMode = FilterMode.Bilinear;
         }


### PR DESCRIPTION
This is a fix for issue #26 (reopened).

The issue is caused by the difference between actual CoC values and TAA-filtered CoC values. Source pixels are only premultiplied by the actual CoC values, and therefore this difference makes underexposure/overexposure artifacts in the succeeding passes.

This change integrates the CoC-TAA pass into the prefilter pass. Now source pixels are properly premultiplied by TAA-filtered CoC values.