### PR TITLE
tweaking grain range to have a lower minimum range

### DIFF
--- a/PostProcessing/Runtime/Models/GrainModel.cs
+++ b/PostProcessing/Runtime/Models/GrainModel.cs
@@ -14,7 +14,7 @@ namespace UnityEngine.PostProcessing
             [Range(0f, 1f), Tooltip("Grain strength. Higher means more visible grain.")]
             public float intensity;
 
-            [Range(1f, 3f), Tooltip("Grain particle size in \"Filmic\" mode.")]
+            [Range(0.3f, 3f), Tooltip("Grain particle size in \"Filmic\" mode.")]
             public float size;
 
             [Range(0f, 1f), Tooltip("Controls the noisiness response curve based on scene luminance. Lower values mean less noise in dark areas.")]


### PR DESCRIPTION
![grain](https://cloud.githubusercontent.com/assets/4518980/21391921/e9b871f4-c78d-11e6-84e1-b0a1b4390c2d.png)

I think the grain value should have a lower minimum size. The size at 1 shows a quite clear texture and is not subtle/fine enough for a lot of desired effects. Changing the lower bound to 0.3 does not create any artifacts and gives a nice film-like grain effect.

A range below 0.3 creates visible patterns and might add artifacts.