### PR TITLE
Antialiasing & grain fixes

### DIFF
--- a/PostProcessing/Resources/Shaders/Uber.shader
+++ b/PostProcessing/Resources/Shaders/Uber.shader
@@ -288,19 +288,6 @@ Shader "Hidden/Post FX/Uber Shader"
 
             color = saturate(color);
 
-            // Grain
-            #if GRAIN
-            {
-                float3 grain = tex2D(_GrainTex, uv * _Grain_Params2.xy + _Grain_Params2.zw).rgb;
-
-                // Noisiness response curve based on scene luminance
-                float lum = 1.0 - sqrt(AcesLuminance(color));
-                lum = lerp(1.0, lum, _Grain_Params1.x);
-
-                color += color * grain * _Grain_Params1.y * lum;
-            }
-            #endif
-
             // Back to gamma space if needed
             #if UNITY_COLORSPACE_GAMMA
             {
@@ -326,6 +313,19 @@ Shader "Hidden/Post FX/Uber Shader"
                 #endif
 
                 color = lerp(color, colorGraded, _UserLut_Params.w);
+            }
+            #endif
+
+            // Grain
+            #if GRAIN
+            {
+                float3 grain = tex2D(_GrainTex, uv * _Grain_Params2.xy + _Grain_Params2.zw).rgb;
+
+                // Noisiness response curve based on scene luminance
+                float lum = 1.0 - sqrt(AcesLuminance(color));
+                lum = lerp(1.0, lum, _Grain_Params1.x);
+
+                color += color * grain * _Grain_Params1.y * lum;
             }
             #endif
 

--- a/PostProcessing/Resources/Shaders/Uber.shader
+++ b/PostProcessing/Resources/Shaders/Uber.shader
@@ -33,6 +33,7 @@ Shader "Hidden/Post FX/Uber Shader"
         #include "UnityCG.cginc"
         #include "Bloom.cginc"
         #include "ColorGrading.cginc"
+        #include "UberSecondPass.cginc"
 
         // Auto exposure / eye adaptation
         sampler2D _AutoExposure;
@@ -63,15 +64,6 @@ Shader "Hidden/Post FX/Uber Shader"
         // User lut
         sampler2D _UserLut;
         half4 _UserLut_Params; // @see _LogLut_Params
-
-        // Grain
-        half2 _Grain_Params1; // x: lum_contrib, y: intensity
-        half4 _Grain_Params2; // x: xscale, h: yscale, z: xoffset, w: yoffset
-        sampler2D _GrainTex;
-
-        // Dithering
-        sampler2D _DitheringTex;
-        float4 _DitheringCoords;
 
         // Vignette
         half3 _Vignette_Color;
@@ -316,29 +308,7 @@ Shader "Hidden/Post FX/Uber Shader"
             }
             #endif
 
-            // Grain
-            #if GRAIN
-            {
-                float3 grain = tex2D(_GrainTex, uv * _Grain_Params2.xy + _Grain_Params2.zw).rgb;
-
-                // Noisiness response curve based on scene luminance
-                float lum = 1.0 - sqrt(AcesLuminance(color));
-                lum = lerp(1.0, lum, _Grain_Params1.x);
-
-                color += color * grain * _Grain_Params1.y * lum;
-            }
-            #endif
-
-            // Blue noise dithering 
-            #if DITHERING
-            {
-                // Symmetric triangular distribution on [-1,1] with maximal density at 0
-                float noise = tex2D(_DitheringTex, uv * _DitheringCoords.xy + _DitheringCoords.zw).a * 2.0 - 1.0;
-                noise = sign(noise) * (1.0 - sqrt(1.0 - abs(noise))) / 255.0;
-
-                color += noise;
-            }
-            #endif
+            color = UberSecondPass(color, uv);
 
             // Done !
             return half4(color, 1.0);

--- a/PostProcessing/Resources/Shaders/UberSecondPass.cginc
+++ b/PostProcessing/Resources/Shaders/UberSecondPass.cginc
@@ -1,0 +1,39 @@
+#include "ColorGrading.cginc"
+
+// Grain
+half2 _Grain_Params1; // x: lum_contrib, y: intensity
+half4 _Grain_Params2; // x: xscale, h: yscale, z: xoffset, w: yoffset
+sampler2D _GrainTex;
+
+// Dithering
+sampler2D _DitheringTex;
+float4 _DitheringCoords;
+
+float3 UberSecondPass(half3 color, float2 uv)
+{
+    // Grain
+    #if GRAIN
+    {
+        float3 grain = tex2D(_GrainTex, uv * _Grain_Params2.xy + _Grain_Params2.zw).rgb;
+
+        // Noisiness response curve based on scene luminance
+        float lum = 1.0 - sqrt(AcesLuminance(color));
+        lum = lerp(1.0, lum, _Grain_Params1.x);
+
+        color += color * grain * _Grain_Params1.y * lum;
+    }
+    #endif
+
+    // Blue noise dithering 
+    #if DITHERING
+    {
+        // Symmetric triangular distribution on [-1,1] with maximal density at 0
+        float noise = tex2D(_DitheringTex, uv * _DitheringCoords.xy + _DitheringCoords.zw).a * 2.0 - 1.0;
+        noise = sign(noise) * (1.0 - sqrt(1.0 - abs(noise))) / 255.0;
+
+        color += noise;
+    }
+    #endif
+
+    return color;
+}

--- a/PostProcessing/Resources/Shaders/UberSecondPass.cginc.meta
+++ b/PostProcessing/Resources/Shaders/UberSecondPass.cginc.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: b6e42614562a56445ba4b5d90301f06f
+timeCreated: 1487080088
+licenseType: Pro
+ShaderImporter:
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/PostProcessing/Runtime/Components/TaaComponent.cs
+++ b/PostProcessing/Runtime/Components/TaaComponent.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine.Rendering;
 
 namespace UnityEngine.PostProcessing
@@ -45,7 +46,7 @@ namespace UnityEngine.PostProcessing
             m_ResetHistory = true;
         }
 
-        public void SetProjectionMatrix()
+        public void SetProjectionMatrix(Func<Vector2, Matrix4x4> jitteredFunc)
         {
             var settings = model.settings.taaSettings;
 
@@ -53,9 +54,17 @@ namespace UnityEngine.PostProcessing
             jitter *= settings.jitterSpread;
 
             context.camera.nonJitteredProjectionMatrix = context.camera.projectionMatrix;
-            context.camera.projectionMatrix = context.camera.orthographic
-                ? GetOrthographicProjectionMatrix(jitter)
-                : GetPerspectiveProjectionMatrix(jitter);
+
+            if (jitteredFunc != null)
+            {
+                context.camera.projectionMatrix = jitteredFunc(jitter);
+            }
+            else
+            {
+                context.camera.projectionMatrix = context.camera.orthographic
+                    ? GetOrthographicProjectionMatrix(jitter)
+                    : GetPerspectiveProjectionMatrix(jitter);
+            }
 
 #if UNITY_5_5_OR_NEWER
             context.camera.useJitteredProjectionMatrixForTransparentRendering = false;

--- a/PostProcessing/Runtime/Components/TaaComponent.cs
+++ b/PostProcessing/Runtime/Components/TaaComponent.cs
@@ -1,5 +1,4 @@
 using System;
-using UnityEngine.Rendering;
 
 namespace UnityEngine.PostProcessing
 {
@@ -207,7 +206,7 @@ namespace UnityEngine.PostProcessing
 
             m_HistoryTexture = null;
             m_SampleIndex = 0;
-	        ResetHistory();
+            ResetHistory();
         }
     }
 }

--- a/PostProcessing/Runtime/PostProcessingBehaviour.cs
+++ b/PostProcessing/Runtime/PostProcessingBehaviour.cs
@@ -16,6 +16,9 @@ namespace UnityEngine.PostProcessing
         // Inspector fields
         public PostProcessingProfile profile;
 
+        public Func<Vector2, Matrix4x4> jitteredMatrixFunc;
+        Matrix4x4 nonJitteredProjectionMatrix;
+
         // Internal helpers
         Dictionary<Type, KeyValuePair<CameraEvent, CommandBuffer>> m_CommandBuffers;
         List<PostProcessingComponentBase> m_Components;
@@ -149,7 +152,10 @@ namespace UnityEngine.PostProcessing
 
             // Temporal antialiasing jittering, needs to happen before culling
             if (!m_RenderingInSceneView && m_Taa.active && !profile.debugViews.willInterrupt)
-                m_Taa.SetProjectionMatrix();
+            {
+                nonJitteredProjectionMatrix = m_Context.camera.projectionMatrix;
+                m_Taa.SetProjectionMatrix(jitteredMatrixFunc);
+            }
         }
 
         void OnPreRender()
@@ -172,7 +178,7 @@ namespace UnityEngine.PostProcessing
                 return;
 
             if (!m_RenderingInSceneView && m_Taa.active && !profile.debugViews.willInterrupt)
-                m_Camera.ResetProjectionMatrix();
+                m_Context.camera.projectionMatrix = nonJitteredProjectionMatrix;
         }
 
         // Classic render target pipeline for RT-based effects

--- a/PostProcessing/Runtime/PostProcessingBehaviour.cs
+++ b/PostProcessing/Runtime/PostProcessingBehaviour.cs
@@ -195,9 +195,6 @@ namespace UnityEngine.PostProcessing
             var uberMaterial = m_MaterialFactory.Get("Hidden/Post FX/Uber Shader");
             uberMaterial.shaderKeywords = null;
 
-            if (!GraphicsUtils.isLinearColorSpace)
-                uberMaterial.EnableKeyword("UNITY_COLORSPACE_GAMMA");
-
             var src = source;
             var dst = destination;
 
@@ -266,7 +263,12 @@ namespace UnityEngine.PostProcessing
                 uberActive |= TryPrepareUberImageEffect(m_Dithering, uberMaterial);
 
                 if (uberActive)
+                {
+                    if (!GraphicsUtils.isLinearColorSpace)
+                        uberMaterial.EnableKeyword("UNITY_COLORSPACE_GAMMA");
+
                     Graphics.Blit(src, dst, uberMaterial, 0);
+                }
             }
 
             if (!uberActive && !fxaaActive)

--- a/PostProcessing/Runtime/PostProcessingBehaviour.cs
+++ b/PostProcessing/Runtime/PostProcessingBehaviour.cs
@@ -171,7 +171,8 @@ namespace UnityEngine.PostProcessing
             if (profile == null || m_Camera == null)
                 return;
 
-            m_Camera.ResetProjectionMatrix();
+            if (!m_RenderingInSceneView && m_Taa.active && !profile.debugViews.willInterrupt)
+                m_Camera.ResetProjectionMatrix();
         }
 
         // Classic render target pipeline for RT-based effects


### PR DESCRIPTION
A bunch of fixes for antialiasing and grain:

- Only resets projection matrix if TAA is enabled (in case users need their own projection matrices) - note that this will still break with custom user matrices if TAA is enabled, we'll need to investigate this later on.
- Grain is now done after LUT grading (because we don't want to color grade the grain, duh).
- Uber is now split in two when FXAA is used so that it's not applied to grain & dithering (#56).