### PR TITLE
Reduced the amount of variants

### DIFF
--- a/PostProcessing/Editor/Models/VignetteModelEditor.cs
+++ b/PostProcessing/Editor/Models/VignetteModelEditor.cs
@@ -17,6 +17,7 @@ namespace UnityEditor.PostProcessing
         SerializedProperty m_Roundness;
         SerializedProperty m_Mask;
         SerializedProperty m_Opacity;
+        SerializedProperty m_Rounded;
 
         public override void OnEnable()
         {
@@ -28,6 +29,7 @@ namespace UnityEditor.PostProcessing
             m_Roundness = FindSetting((Settings x) => x.roundness);
             m_Mask = FindSetting((Settings x) => x.mask);
             m_Opacity = FindSetting((Settings x) => x.opacity);
+            m_Rounded = FindSetting((Settings x) => x.rounded);
         }
 
         public override void OnInspectorGUI()
@@ -40,9 +42,8 @@ namespace UnityEditor.PostProcessing
                 EditorGUILayout.PropertyField(m_Center);
                 EditorGUILayout.PropertyField(m_Intensity);
                 EditorGUILayout.PropertyField(m_Smoothness);
-
-                if (m_Mode.intValue == (int)VignetteMode.Classic)
-                    EditorGUILayout.PropertyField(m_Roundness);
+                EditorGUILayout.PropertyField(m_Roundness);
+                EditorGUILayout.PropertyField(m_Rounded);
             }
             else
             {

--- a/PostProcessing/Editor/Models/VignetteModelEditor.cs
+++ b/PostProcessing/Editor/Models/VignetteModelEditor.cs
@@ -35,7 +35,7 @@ namespace UnityEditor.PostProcessing
             EditorGUILayout.PropertyField(m_Mode);
             EditorGUILayout.PropertyField(m_Color);
 
-            if (m_Mode.intValue <= (int)VignetteMode.Round)
+            if (m_Mode.intValue < (int)VignetteMode.Masked)
             {
                 EditorGUILayout.PropertyField(m_Center);
                 EditorGUILayout.PropertyField(m_Intensity);

--- a/PostProcessing/Resources/Shaders/Bloom.shader
+++ b/PostProcessing/Resources/Shaders/Bloom.shader
@@ -79,11 +79,7 @@ Shader "Hidden/Post FX/Bloom"
         {
             float autoExposure = 1.0;
             uv = UnityStereoScreenSpaceUVAdjust(uv, _MainTex_ST);
-
-        #if EYE_ADAPTATION
             autoExposure = tex2D(_AutoExposure, uv).r;
-        #endif
-
             return tex2D(tex, uv) * autoExposure;
         }
 
@@ -151,7 +147,6 @@ Shader "Hidden/Post FX/Bloom"
         Pass
         {
             CGPROGRAM
-                #pragma multi_compile __ EYE_ADAPTATION
                 #pragma multi_compile __ ANTI_FLICKER
                 #pragma multi_compile __ UNITY_COLORSPACE_GAMMA
                 #pragma vertex VertDefault

--- a/PostProcessing/Resources/Shaders/Uber.shader
+++ b/PostProcessing/Resources/Shaders/Uber.shader
@@ -66,7 +66,7 @@ Shader "Hidden/Post FX/Uber Shader"
         // Vignette
         half3 _Vignette_Color;
         half2 _Vignette_Center; // UV space
-        half3 _Vignette_Settings; // x: intensity, y: smoothness, z: roundness
+        half4 _Vignette_Settings; // x: intensity, y: smoothness, z: roundness, w: rounded
         sampler2D _Vignette_Mask;
         half _Vignette_Opacity; // [0;1]
 
@@ -227,7 +227,7 @@ Shader "Hidden/Post FX/Uber Shader"
             #if VIGNETTE_CLASSIC
             {
                 half2 d = abs(uv - _Vignette_Center) * _Vignette_Settings.x;
-                d.x *= _ScreenParams.x / _ScreenParams.y;
+                d.x *= lerp(1.0, _ScreenParams.x / _ScreenParams.y, _Vignette_Settings.w);
                 d = pow(d, _Vignette_Settings.z); // Roundness
                 half vfactor = pow(saturate(1.0 - dot(d, d)), _Vignette_Settings.y);
                 color *= lerp(_Vignette_Color, (1.0).xxx, vfactor);

--- a/PostProcessing/Resources/Shaders/Uber.shader
+++ b/PostProcessing/Resources/Shaders/Uber.shader
@@ -19,14 +19,13 @@ Shader "Hidden/Post FX/Uber Shader"
         #pragma target 3.0
 
         #pragma multi_compile __ UNITY_COLORSPACE_GAMMA
-        #pragma multi_compile __ EYE_ADAPTATION
         #pragma multi_compile __ CHROMATIC_ABERRATION
         #pragma multi_compile __ DEPTH_OF_FIELD DEPTH_OF_FIELD_COC_VIEW
         #pragma multi_compile __ BLOOM BLOOM_LENS_DIRT
         #pragma multi_compile __ COLOR_GRADING COLOR_GRADING_LOG_VIEW
         #pragma multi_compile __ USER_LUT
         #pragma multi_compile __ GRAIN
-        #pragma multi_compile __ VIGNETTE_CLASSIC VIGNETTE_ROUND VIGNETTE_MASKED
+        #pragma multi_compile __ VIGNETTE_CLASSIC VIGNETTE_MASKED
         #pragma multi_compile __ DITHERING
 
         #include "UnityCG.cginc"
@@ -101,14 +100,7 @@ Shader "Hidden/Post FX/Uber Shader"
         half4 FragUber(VaryingsFlipped i) : SV_Target
         {
             float2 uv = i.uv;
-            half autoExposure = 1.0;
-
-            // Store the auto exposure value for later
-            #if EYE_ADAPTATION
-            {
-                autoExposure = tex2D(_AutoExposure, uv).r;
-            }
-            #endif
+            half autoExposure = tex2D(_AutoExposure, uv).r;
 
             half3 color = (0.0).xxx;
             #if DEPTH_OF_FIELD && CHROMATIC_ABERRATION
@@ -235,16 +227,8 @@ Shader "Hidden/Post FX/Uber Shader"
             #if VIGNETTE_CLASSIC
             {
                 half2 d = abs(uv - _Vignette_Center) * _Vignette_Settings.x;
-                d = pow(d, _Vignette_Settings.z); // Roundness
-                half vfactor = pow(saturate(1.0 - dot(d, d)), _Vignette_Settings.y);
-                color *= lerp(_Vignette_Color, (1.0).xxx, vfactor);
-            }
-
-            // Perfectly round vignette
-            #elif VIGNETTE_ROUND
-            {
-                half2 d = abs(uv - _Vignette_Center) * _Vignette_Settings.x;
                 d.x *= _ScreenParams.x / _ScreenParams.y;
+                d = pow(d, _Vignette_Settings.z); // Roundness
                 half vfactor = pow(saturate(1.0 - dot(d, d)), _Vignette_Settings.y);
                 color *= lerp(_Vignette_Color, (1.0).xxx, vfactor);
             }

--- a/PostProcessing/Runtime/Components/BloomComponent.cs
+++ b/PostProcessing/Runtime/Components/BloomComponent.cs
@@ -37,12 +37,8 @@ namespace UnityEngine.PostProcessing
             var material = context.materialFactory.Get("Hidden/Post FX/Bloom");
             material.shaderKeywords = null;
 
-            // Apply auto exposure before the prefiltering pass if needed
-            if (autoExposure != null)
-            {
-                material.EnableKeyword("EYE_ADAPTATION");
-                material.SetTexture(Uniforms._AutoExposure, autoExposure);
-            }
+            // Apply auto exposure before the prefiltering pass
+            material.SetTexture(Uniforms._AutoExposure, autoExposure);
 
             // Do bloom on a half-res buffer, full-res doesn't bring much and kills performances on
             // fillrate limited platforms

--- a/PostProcessing/Runtime/Components/EyeAdaptationComponent.cs
+++ b/PostProcessing/Runtime/Components/EyeAdaptationComponent.cs
@@ -149,10 +149,6 @@ namespace UnityEngine.PostProcessing
                 m_CurrentAutoExposure = dst;
             }
 
-            // Uber setup
-            uberMaterial.EnableKeyword("EYE_ADAPTATION");
-            uberMaterial.SetTexture(Uniforms._AutoExposure, m_CurrentAutoExposure);
-
             // Generate debug histogram
             if (context.profile.debugViews.IsModeActive(BuiltinDebugViewsModel.Mode.EyeAdaptation))
             {

--- a/PostProcessing/Runtime/Components/VignetteComponent.cs
+++ b/PostProcessing/Runtime/Components/VignetteComponent.cs
@@ -30,7 +30,7 @@ namespace UnityEngine.PostProcessing
                 uberMaterial.SetVector(Uniforms._Vignette_Center, settings.center);
                 uberMaterial.EnableKeyword("VIGNETTE_CLASSIC");
                 float roundness = (1f - settings.roundness) * 6f + settings.roundness;
-                uberMaterial.SetVector(Uniforms._Vignette_Settings, new Vector3(settings.intensity * 3f, settings.smoothness * 5f, roundness));
+                uberMaterial.SetVector(Uniforms._Vignette_Settings, new Vector4(settings.intensity * 3f, settings.smoothness * 5f, roundness, settings.rounded ? 1f : 0f));
             }
             else if (settings.mode == VignetteModel.Mode.Masked)
             {

--- a/PostProcessing/Runtime/Components/VignetteComponent.cs
+++ b/PostProcessing/Runtime/Components/VignetteComponent.cs
@@ -32,12 +32,6 @@ namespace UnityEngine.PostProcessing
                 float roundness = (1f - settings.roundness) * 6f + settings.roundness;
                 uberMaterial.SetVector(Uniforms._Vignette_Settings, new Vector3(settings.intensity * 3f, settings.smoothness * 5f, roundness));
             }
-            else if (settings.mode == VignetteModel.Mode.Round)
-            {
-                uberMaterial.SetVector(Uniforms._Vignette_Center, settings.center);
-                uberMaterial.EnableKeyword("VIGNETTE_ROUND");
-                uberMaterial.SetVector(Uniforms._Vignette_Settings, new Vector3(settings.intensity * 3f, settings.smoothness * 5f, 1f));
-            }
             else if (settings.mode == VignetteModel.Mode.Masked)
             {
                 if (settings.mask != null && settings.opacity > 0f)

--- a/PostProcessing/Runtime/Models/VignetteModel.cs
+++ b/PostProcessing/Runtime/Models/VignetteModel.cs
@@ -8,7 +8,6 @@ namespace UnityEngine.PostProcessing
         public enum Mode
         {
             Classic,
-            Round,
             Masked
         }
 

--- a/PostProcessing/Runtime/Models/VignetteModel.cs
+++ b/PostProcessing/Runtime/Models/VignetteModel.cs
@@ -39,6 +39,9 @@ namespace UnityEngine.PostProcessing
             [Range(0f, 1f), Tooltip("Mask opacity.")]
             public float opacity;
 
+            [Tooltip("Should the vignette be perfectly round or be dependent on the current aspect ratio?")]
+            public bool rounded;
+
             public static Settings defaultSettings
             {
                 get
@@ -52,7 +55,8 @@ namespace UnityEngine.PostProcessing
                         smoothness = 0.2f,
                         roundness = 1f,
                         mask = null,
-                        opacity = 1f
+                        opacity = 1f,
+                        rounded = false
                     };
                 }
             }

--- a/PostProcessing/Runtime/PostProcessingBehaviour.cs
+++ b/PostProcessing/Runtime/PostProcessingBehaviour.cs
@@ -220,12 +220,14 @@ namespace UnityEngine.PostProcessing
                 dst = m_RenderTextureFactory.Get(src);
 #endif
 
-            Texture autoExposure = null;
+            Texture autoExposure = GraphicsUtils.whiteTexture;
             if (m_EyeAdaptation.active)
             {
                 uberActive = true;
                 autoExposure = m_EyeAdaptation.Prepare(src, uberMaterial);
             }
+
+            uberMaterial.SetTexture("_AutoExposure", autoExposure);
 
             if (dofActive)
             {

--- a/PostProcessing/Runtime/Utils/GraphicsUtils.cs
+++ b/PostProcessing/Runtime/Utils/GraphicsUtils.cs
@@ -18,6 +18,22 @@ namespace UnityEngine.PostProcessing
 #endif
         }
 
+        static Texture2D s_WhiteTexture;
+        public static Texture2D whiteTexture
+        {
+            get
+            {
+                if (s_WhiteTexture != null)
+                    return s_WhiteTexture;
+
+                s_WhiteTexture = new Texture2D(1, 1, TextureFormat.ARGB32, false);
+                s_WhiteTexture.SetPixel(0, 0, new Color(1f, 1f, 1f, 1f));
+                s_WhiteTexture.Apply();
+
+                return s_WhiteTexture;
+            }
+        }
+
         static Mesh s_Quad;
         public static Mesh quad
         {


### PR DESCRIPTION
Also saved 2 shader keywords & merged vignette "classic" and "round" because there was no point in having separate variants just to save an instruction.

Variant count is down to 6912 -> 2592.