### PR TITLE
New temporal filter for DoF

### DIFF
--- a/PostProcessing/Resources/Shaders/Common.cginc
+++ b/PostProcessing/Resources/Shaders/Common.cginc
@@ -16,7 +16,12 @@
 // -----------------------------------------------------------------------------
 // Uniforms
 
+#if defined(SEPARATE_TEXTURE_SAMPLER)
+Texture2D _MainTex;
+SamplerState sampler_MainTex;
+#else
 sampler2D _MainTex;
+#endif
 float4 _MainTex_TexelSize;
 float4 _MainTex_ST;
 

--- a/PostProcessing/Resources/Shaders/DepthOfField.cginc
+++ b/PostProcessing/Resources/Shaders/DepthOfField.cginc
@@ -1,15 +1,22 @@
 #ifndef __DEPTH_OF_FIELD__
 #define __DEPTH_OF_FIELD__
 
-#include "UnityCG.cginc"
+#if SHADER_TARGET >= 50
+    // Use separate texture/sampler objects on Shader Model 5.0
+    #define SEPARATE_TEXTURE_SAMPLER
+    #define DOF_DECL_TEX2D(tex) Texture2D tex; SamplerState sampler##tex
+    #define DOF_TEX2D(tex, coord) tex.Sample(sampler##tex, coord)
+#else
+    #define DOF_DECL_TEX2D(tex) sampler2D tex
+    #define DOF_TEX2D(tex, coord) tex2D(tex, coord)
+#endif
+
 #include "Common.cginc"
 #include "DiskKernels.cginc"
 
-#define PREFILTER_LUMA_WEIGHT 1
-
-sampler2D_float _CameraDepthTexture;
-sampler2D_float _HistoryCoC;
-float _HistoryWeight;
+DOF_DECL_TEX2D(_CameraDepthTexture);
+DOF_DECL_TEX2D(_CameraMotionVectorsTexture);
+DOF_DECL_TEX2D(_CoCTex);
 
 // Camera parameters
 float _Distance;
@@ -17,6 +24,7 @@ float _LensCoeff;  // f^2 / (N * (S1 - f) * film_width * 2)
 float _MaxCoC;
 float _RcpMaxCoC;
 float _RcpAspect;
+half3 _TaaParams; // Jitter.x, Jitter.y, Blending
 
 struct VaryingsDOF
 {
@@ -47,75 +55,114 @@ VaryingsDOF VertDOF(AttributesDefault v)
     return o;
 }
 
-// Prefilter: CoC calculation, downsampling and premultiplying.
-
-#if defined(PREFILTER_TAA)
-
-// TAA enabled: use MRT to update the history buffer in the same pass.
-struct PrefilterOutput
+// CoC calculation
+half4 FragCoC(VaryingsDOF i) : SV_Target
 {
-    half4 base : SV_Target0;
-    half4 history : SV_Target1;
-};
-#define PrefilterSemantics
+    float depth = LinearEyeDepth(DOF_TEX2D(_CameraDepthTexture, i.uv));
+    half coc = (depth - _Distance) * _LensCoeff / max(depth, 1e-5);
+    return saturate(coc * 0.5 * _RcpMaxCoC + 0.5);
+}
+
+// Temporal filter
+half4 FragTempFilter(VaryingsDOF i) : SV_Target
+{
+    float3 uvOffs = _MainTex_TexelSize.xyy * float3(1, 1, 0);
+
+#if defined(SEPARATE_TEXTURE_SAMPLER)
+
+    half4 cocTL = _CoCTex.GatherRed(sampler_CoCTex, i.uv - uvOffs.xy * 0.5); // top-left
+    half4 cocBR = _CoCTex.GatherRed(sampler_CoCTex, i.uv + uvOffs.xy * 0.5); // bottom-right
+    half coc1 = cocTL.x; // top
+    half coc2 = cocTL.z; // left
+    half coc3 = cocBR.x; // bottom
+    half coc4 = cocBR.z; // right
 
 #else
 
-// No TAA
-#define PrefilterOutput half4
-#define PrefilterSemantics :SV_Target
+    half coc1 = DOF_TEX2D(_CoCTex, i.uv - uvOffs.xz).r; // top
+    half coc2 = DOF_TEX2D(_CoCTex, i.uv - uvOffs.zy).r; // left
+    half coc3 = DOF_TEX2D(_CoCTex, i.uv + uvOffs.zy).r; // bottom
+    half coc4 = DOF_TEX2D(_CoCTex, i.uv + uvOffs.xz).r; // right
 
 #endif
 
-PrefilterOutput FragPrefilter(VaryingsDOF i) PrefilterSemantics
+    // Dejittered center sample.
+    half coc0 = DOF_TEX2D(_CoCTex, i.uv - _TaaParams.xy).r;
+
+    // CoC dilation: determine the closest point in the four neighbors.
+    float3 closest = float3(0, 0, coc0);
+    closest = coc1 < closest.z ? float3(-uvOffs.xz, coc1) : closest;
+    closest = coc2 < closest.z ? float3(-uvOffs.zy, coc2) : closest;
+    closest = coc3 < closest.z ? float3(+uvOffs.zy, coc3) : closest;
+    closest = coc4 < closest.z ? float3(+uvOffs.xz, coc4) : closest;
+
+    // Sample the history buffer with the motion vector at the closest point.
+    float2 motion = DOF_TEX2D(_CameraMotionVectorsTexture, i.uv + closest.xy).xy;
+    half cocHis = DOF_TEX2D(_MainTex, i.uv - motion).r;
+
+    // Neighborhood clamping.
+    half cocMin = closest.z;
+    half cocMax = max(max(max(max(coc0, coc1), coc2), coc3), coc4);
+    cocHis = clamp(cocHis, cocMin, cocMax);
+
+    // Blend with the history.
+    return lerp(coc0, cocHis, _TaaParams.z);
+}
+
+// Prefilter: downsampling and premultiplying.
+half4 FragPrefilter(VaryingsDOF i) : SV_Target
 {
+#if defined(SEPARATE_TEXTURE_SAMPLER)
+
+    // Sample source colors.
+    half4 c_r = _MainTex.GatherRed  (sampler_MainTex, i.uv);
+    half4 c_g = _MainTex.GatherGreen(sampler_MainTex, i.uv);
+    half4 c_b = _MainTex.GatherBlue (sampler_MainTex, i.uv);
+
+    half3 c0 = half3(c_r.x, c_g.x, c_b.x);
+    half3 c1 = half3(c_r.y, c_g.y, c_b.y);
+    half3 c2 = half3(c_r.z, c_g.z, c_b.z);
+    half3 c3 = half3(c_r.w, c_g.w, c_b.w);
+
+    // Sample CoCs.
+    half4 cocs = _CoCTex.Gather(sampler_CoCTex, i.uvAlt) * 2.0 - 1.0;
+    half coc0 = cocs.x;
+    half coc1 = cocs.y;
+    half coc2 = cocs.z;
+    half coc3 = cocs.w;
+
+#else
+
     float3 duv = _MainTex_TexelSize.xyx * float3(0.5, 0.5, -0.5);
 
     // Sample source colors.
-    half3 c0 = tex2D(_MainTex, i.uv - duv.xy).rgb;
-    half3 c1 = tex2D(_MainTex, i.uv - duv.zy).rgb;
-    half3 c2 = tex2D(_MainTex, i.uv + duv.zy).rgb;
-    half3 c3 = tex2D(_MainTex, i.uv + duv.xy).rgb;
+    half3 c0 = DOF_TEX2D(_MainTex, i.uv - duv.xy).rgb;
+    half3 c1 = DOF_TEX2D(_MainTex, i.uv - duv.zy).rgb;
+    half3 c2 = DOF_TEX2D(_MainTex, i.uv + duv.zy).rgb;
+    half3 c3 = DOF_TEX2D(_MainTex, i.uv + duv.xy).rgb;
 
-    // Sample linear depths.
-    float d0 = LinearEyeDepth(SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, i.uvAlt - duv.xy));
-    float d1 = LinearEyeDepth(SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, i.uvAlt - duv.zy));
-    float d2 = LinearEyeDepth(SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, i.uvAlt + duv.zy));
-    float d3 = LinearEyeDepth(SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, i.uvAlt + duv.xy));
-    float4 depths = float4(d0, d1, d2, d3);
+    // Sample CoCs.
+    half coc0 = DOF_TEX2D(_CoCTex, i.uvAlt - duv.xy).r * 2.0 - 1.0;
+    half coc1 = DOF_TEX2D(_CoCTex, i.uvAlt - duv.zy).r * 2.0 - 1.0;
+    half coc2 = DOF_TEX2D(_CoCTex, i.uvAlt + duv.zy).r * 2.0 - 1.0;
+    half coc3 = DOF_TEX2D(_CoCTex, i.uvAlt + duv.xy).r * 2.0 - 1.0;
 
-    // Calculate the radiuses of CoCs at these sample points.
-    float4 cocs = (depths - _Distance) * _LensCoeff / depths;
-    cocs = clamp(cocs, -_MaxCoC, _MaxCoC);
-
-#if defined(PREFILTER_TAA)
-    // Get the average with the history to avoid temporal aliasing.
-    half hcoc = tex2D(_HistoryCoC, i.uv).r;
-    cocs = lerp(cocs, hcoc, _HistoryWeight);
 #endif
 
-    // Premultiply CoC to reduce background bleeding.
-    float4 weights = saturate(abs(cocs) * _RcpMaxCoC);
-
-#if defined(PREFILTER_LUMA_WEIGHT)
-    // Apply luma weights to reduce flickering.
-    // References:
-    //   http://gpuopen.com/optimized-reversible-tonemapper-for-resolve/
-    //   http://graphicrants.blogspot.fr/2013/12/tone-mapping.html
-    weights.x *= 1.0 / (Max3(c0) + 1.0);
-    weights.y *= 1.0 / (Max3(c1) + 1.0);
-    weights.z *= 1.0 / (Max3(c2) + 1.0);
-    weights.w *= 1.0 / (Max3(c3) + 1.0);
-#endif
+    // Apply CoC and luma weights to reduce bleeding and flickering.
+    float w0 = abs(coc0) / (Max3(c0) + 1.0);
+    float w1 = abs(coc1) / (Max3(c1) + 1.0);
+    float w2 = abs(coc2) / (Max3(c2) + 1.0);
+    float w3 = abs(coc3) / (Max3(c3) + 1.0);
 
     // Weighted average of the color samples
-    half3 avg = c0 * weights.x + c1 * weights.y + c2 * weights.z + c3 * weights.w;
-    avg /= dot(weights, 1.0);
+    half3 avg = c0 * w0 + c1 * w1 + c2 * w2 + c3 * w3;
+    avg /= max(w0 + w1 + w2 + w3, 1e-5);
 
-    // Output CoC = average of CoCs
-    half cocmin = Min4(cocs);
-    half cocmax = Max4(cocs);
-    half coc = -cocmin > cocmax ? cocmin : cocmax;
+    // Select the largest CoC value.
+    half coc_min = Min4(coc0, coc1, coc2, coc3);
+    half coc_max = Max4(coc0, coc1, coc2, coc3);
+    half coc = (-coc_min > coc_max ? coc_min : coc_max) * _MaxCoC;
 
     // Premultiply CoC again.
     avg *= smoothstep(0, _MainTex_TexelSize.y * 2, abs(coc));
@@ -124,20 +171,13 @@ PrefilterOutput FragPrefilter(VaryingsDOF i) PrefilterSemantics
     avg = GammaToLinearSpace(avg);
 #endif
 
-#if defined(PREFILTER_TAA)
-    PrefilterOutput output;
-    output.base = half4(avg, coc);
-    output.history = coc.xxxx;
-    return output;
-#else
     return half4(avg, coc);
-#endif
 }
 
 // Bokeh filter with disk-shaped kernels
 half4 FragBlur(VaryingsDOF i) : SV_Target
 {
-    half4 samp0 = tex2D(_MainTex, i.uv);
+    half4 samp0 = DOF_TEX2D(_MainTex, i.uv);
 
     half4 bgAcc = 0.0; // Background: far field bokeh
     half4 fgAcc = 0.0; // Foreground: near field bokeh
@@ -148,7 +188,7 @@ half4 FragBlur(VaryingsDOF i) : SV_Target
         float dist = length(disp);
 
         float2 duv = float2(disp.x * _RcpAspect, disp.y);
-        half4 samp = tex2D(_MainTex, i.uv + duv);
+        half4 samp = DOF_TEX2D(_MainTex, i.uv + duv);
 
         // BG: Compare CoC of the current sample and the center sample
         // and select smaller one.
@@ -181,12 +221,8 @@ half4 FragBlur(VaryingsDOF i) : SV_Target
     fgAcc.a *= UNITY_PI / kSampleCount;
 
     // Alpha premultiplying
-    half3 rgb = 0.0;
-    rgb = lerp(rgb, bgAcc.rgb, saturate(bgAcc.a));
-    rgb = lerp(rgb, fgAcc.rgb, saturate(fgAcc.a));
-
-    // Combined alpha value
-    half alpha = (1.0 - saturate(bgAcc.a)) * (1.0 - saturate(fgAcc.a));
+    half alpha = saturate(fgAcc.a);
+    half3 rgb = lerp(bgAcc.rgb, fgAcc.rgb, alpha);
 
     return half4(rgb, alpha);
 }
@@ -194,37 +230,14 @@ half4 FragBlur(VaryingsDOF i) : SV_Target
 // Postfilter blur
 half4 FragPostBlur(VaryingsDOF i) : SV_Target
 {
-    // 9-tap tent filter
-    float4 duv = _MainTex_TexelSize.xyxy * float4(1, 1, -1, 0);
-
-    half4 c0 = tex2D(_MainTex, i.uv - duv.xy);
-    half4 c1 = tex2D(_MainTex, i.uv - duv.wy);
-    half4 c2 = tex2D(_MainTex, i.uv - duv.zy);
-
-    half4 c3 = tex2D(_MainTex, i.uv + duv.zw);
-    half4 c4 = tex2D(_MainTex, i.uv         );
-    half4 c5 = tex2D(_MainTex, i.uv + duv.xw);
-
-    half4 c6 = tex2D(_MainTex, i.uv + duv.zy);
-    half4 c7 = tex2D(_MainTex, i.uv + duv.wy);
-    half4 c8 = tex2D(_MainTex, i.uv + duv.xy);
-
-    half4 acc = c0 * 1 + c1 * 2 + c2 * 1 +
-                c3 * 2 + c4 * 4 + c5 * 2 +
-                c6 * 1 + c7 * 2 + c8 * 1;
-
-    half aa =
-        c0.a * c0.a * 1 + c1.a * c1.a * 2 + c2.a * c2.a * 1 +
-        c3.a * c3.a * 2 + c4.a * c4.a * 4 + c5.a * c5.a * 2 +
-        c6.a * c6.a * 1 + c7.a * c7.a * 2 + c8.a * c8.a * 1;
-
-    half wb = 1.2;
-    half a = (wb * acc.a - aa) / (wb * 16 - acc.a);
-
-    acc /= 16;
-
-    half3 rgb = acc.rgb * (1 + saturate(acc.a - a));
-    return half4(rgb, a);
+    // 9 tap tent filter with 4 bilinear samples
+    const float4 duv = _MainTex_TexelSize.xyxy * float4(0.5, 0.5, -0.5, 0);
+    half4 acc;
+    acc  = DOF_TEX2D(_MainTex, i.uv - duv.xy);
+    acc += DOF_TEX2D(_MainTex, i.uv - duv.zy);
+    acc += DOF_TEX2D(_MainTex, i.uv + duv.zy);
+    acc += DOF_TEX2D(_MainTex, i.uv + duv.xy);
+    return acc / 4.0;
 }
 
 #endif // __DEPTH_OF_FIELD__

--- a/PostProcessing/Resources/Shaders/DepthOfField.shader
+++ b/PostProcessing/Resources/Shaders/DepthOfField.shader
@@ -7,39 +7,53 @@ Shader "Hidden/Post FX/Depth Of Field"
 
     CGINCLUDE
         #pragma exclude_renderers d3d11_9x
-        #pragma target 3.0
     ENDCG
 
+    // SubShader with SM 5.0 support
+    // Gather intrinsics are used to reduce texture sample count.
     SubShader
     {
         Cull Off ZWrite Off ZTest Always
 
-        // (0) Downsampling, prefiltering & CoC
-        Pass
+        Pass // 0
         {
+            Name "CoC Calculation"
             CGPROGRAM
+                #pragma target 3.0
+                #pragma vertex VertDOF
+                #pragma fragment FragCoC
+                #include "DepthOfField.cginc"
+            ENDCG
+        }
+
+        Pass // 1
+        {
+            Name "CoC Temporal Filter"
+            CGPROGRAM
+                #pragma target 5.0
+                #pragma vertex VertDOF
+                #pragma fragment FragTempFilter
+                #include "DepthOfField.cginc"
+            ENDCG
+        }
+
+        Pass // 2
+        {
+            Name "Downsample and Prefilter"
+            CGPROGRAM
+                #pragma target 5.0
+                #pragma vertex VertDOF
+                #pragma fragment FragPrefilter
                 #pragma multi_compile __ UNITY_COLORSPACE_GAMMA
-                #pragma vertex VertDOF
-                #pragma fragment FragPrefilter
                 #include "DepthOfField.cginc"
             ENDCG
         }
 
-        // (1) Pass 0 + temporal antialiasing
-        Pass
+        Pass // 3
         {
+            Name "Bokeh Filter (small)"
             CGPROGRAM
-                #pragma vertex VertDOF
-                #pragma fragment FragPrefilter
-                #define PREFILTER_TAA
-                #include "DepthOfField.cginc"
-            ENDCG
-        }
-
-        // (2-5) Bokeh filter with disk-shaped kernels
-        Pass
-        {
-            CGPROGRAM
+                #pragma target 3.0
                 #pragma vertex VertDOF
                 #pragma fragment FragBlur
                 #define KERNEL_SMALL
@@ -47,9 +61,11 @@ Shader "Hidden/Post FX/Depth Of Field"
             ENDCG
         }
 
-        Pass
+        Pass // 4
         {
+            Name "Bokeh Filter (medium)"
             CGPROGRAM
+                #pragma target 3.0
                 #pragma vertex VertDOF
                 #pragma fragment FragBlur
                 #define KERNEL_MEDIUM
@@ -57,9 +73,11 @@ Shader "Hidden/Post FX/Depth Of Field"
             ENDCG
         }
 
-        Pass
+        Pass // 5
         {
+            Name "Bokeh Filter (large)"
             CGPROGRAM
+                #pragma target 3.0
                 #pragma vertex VertDOF
                 #pragma fragment FragBlur
                 #define KERNEL_LARGE
@@ -67,9 +85,11 @@ Shader "Hidden/Post FX/Depth Of Field"
             ENDCG
         }
 
-        Pass
+        Pass // 6
         {
+            Name "Bokeh Filter (very large)"
             CGPROGRAM
+                #pragma target 3.0
                 #pragma vertex VertDOF
                 #pragma fragment FragBlur
                 #define KERNEL_VERYLARGE
@@ -77,10 +97,110 @@ Shader "Hidden/Post FX/Depth Of Field"
             ENDCG
         }
 
-        // (6) Postfilter blur
-        Pass
+        Pass // 7
         {
+            Name "Postfilter"
             CGPROGRAM
+                #pragma target 3.0
+                #pragma vertex VertDOF
+                #pragma fragment FragPostBlur
+                #include "DepthOfField.cginc"
+            ENDCG
+        }
+    }
+
+    // Fallback SubShader with SM 3.0
+    SubShader
+    {
+        Cull Off ZWrite Off ZTest Always
+
+        Pass // 0
+        {
+            Name "CoC Calculation"
+            CGPROGRAM
+                #pragma target 3.0
+                #pragma vertex VertDOF
+                #pragma fragment FragCoC
+                #include "DepthOfField.cginc"
+            ENDCG
+        }
+
+        Pass // 1
+        {
+            Name "CoC Temporal Filter"
+            CGPROGRAM
+                #pragma target 3.0
+                #pragma vertex VertDOF
+                #pragma fragment FragTempFilter
+                #include "DepthOfField.cginc"
+            ENDCG
+        }
+
+        Pass // 2
+        {
+            Name "Downsample and Prefilter"
+            CGPROGRAM
+                #pragma target 3.0
+                #pragma vertex VertDOF
+                #pragma fragment FragPrefilter
+                #pragma multi_compile __ UNITY_COLORSPACE_GAMMA
+                #include "DepthOfField.cginc"
+            ENDCG
+        }
+
+        Pass // 3
+        {
+            Name "Bokeh Filter (small)"
+            CGPROGRAM
+                #pragma target 3.0
+                #pragma vertex VertDOF
+                #pragma fragment FragBlur
+                #define KERNEL_SMALL
+                #include "DepthOfField.cginc"
+            ENDCG
+        }
+
+        Pass // 4
+        {
+            Name "Bokeh Filter (medium)"
+            CGPROGRAM
+                #pragma target 3.0
+                #pragma vertex VertDOF
+                #pragma fragment FragBlur
+                #define KERNEL_MEDIUM
+                #include "DepthOfField.cginc"
+            ENDCG
+        }
+
+        Pass // 5
+        {
+            Name "Bokeh Filter (large)"
+            CGPROGRAM
+                #pragma target 3.0
+                #pragma vertex VertDOF
+                #pragma fragment FragBlur
+                #define KERNEL_LARGE
+                #include "DepthOfField.cginc"
+            ENDCG
+        }
+
+        Pass // 6
+        {
+            Name "Bokeh Filter (very large)"
+            CGPROGRAM
+                #pragma target 3.0
+                #pragma vertex VertDOF
+                #pragma fragment FragBlur
+                #define KERNEL_VERYLARGE
+                #include "DepthOfField.cginc"
+            ENDCG
+        }
+
+        Pass // 7
+        {
+            Name "Postfilter"
+            CGPROGRAM
+                #pragma target 3.0
                 #pragma vertex VertDOF
                 #pragma fragment FragPostBlur
                 #include "DepthOfField.cginc"

--- a/PostProcessing/Runtime/Components/DepthOfFieldComponent.cs
+++ b/PostProcessing/Runtime/Components/DepthOfFieldComponent.cs
@@ -84,6 +84,12 @@ namespace UnityEngine.PostProcessing
             var colorFormat = RenderTextureFormat.ARGBHalf;
             var cocFormat = SelectFormat(RenderTextureFormat.R8, RenderTextureFormat.RHalf);
 
+            // Avoid using R8 on OSX with Metal. #896121, https://goo.gl/MgKqu6
+            #if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
+            if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Metal)
+                cocFormat = SelectFormat(RenderTextureFormat.RHalf, RenderTextureFormat.Default);
+            #endif
+
             // Material setup
             var f = CalculateFocalLength();
             var s1 = Mathf.Max(settings.focusDistance, f);

--- a/PostProcessing/Runtime/Components/DepthOfFieldComponent.cs
+++ b/PostProcessing/Runtime/Components/DepthOfFieldComponent.cs
@@ -9,14 +9,15 @@ namespace UnityEngine.PostProcessing
         static class Uniforms
         {
             internal static readonly int _DepthOfFieldTex    = Shader.PropertyToID("_DepthOfFieldTex");
+            internal static readonly int _DepthOfFieldCoCTex = Shader.PropertyToID("_DepthOfFieldCoCTex");
             internal static readonly int _Distance           = Shader.PropertyToID("_Distance");
             internal static readonly int _LensCoeff          = Shader.PropertyToID("_LensCoeff");
             internal static readonly int _MaxCoC             = Shader.PropertyToID("_MaxCoC");
             internal static readonly int _RcpMaxCoC          = Shader.PropertyToID("_RcpMaxCoC");
             internal static readonly int _RcpAspect          = Shader.PropertyToID("_RcpAspect");
             internal static readonly int _MainTex            = Shader.PropertyToID("_MainTex");
-            internal static readonly int _HistoryCoC         = Shader.PropertyToID("_HistoryCoC");
-            internal static readonly int _HistoryWeight      = Shader.PropertyToID("_HistoryWeight");
+            internal static readonly int _CoCTex             = Shader.PropertyToID("_CoCTex");
+            internal static readonly int _TaaParams          = Shader.PropertyToID("_TaaParams");
             internal static readonly int _DepthOfFieldParams = Shader.PropertyToID("_DepthOfFieldParams");
         }
 
@@ -28,7 +29,6 @@ namespace UnityEngine.PostProcessing
             {
                 return model.enabled
                        && SystemInfo.SupportsRenderTextureFormat(RenderTextureFormat.ARGBHalf)
-                       && SystemInfo.SupportsRenderTextureFormat(RenderTextureFormat.RHalf)
                        && !context.interrupted;
             }
         }
@@ -39,7 +39,6 @@ namespace UnityEngine.PostProcessing
         }
 
         RenderTexture m_CoCHistory;
-        RenderBuffer[] m_MRT = new RenderBuffer[2];
 
         // Height of the 35mm full-frame format (36mm x 24mm)
         const float k_FilmHeight = 0.024f;
@@ -66,78 +65,88 @@ namespace UnityEngine.PostProcessing
             return Mathf.Min(0.05f, radiusInPixels / screenHeight);
         }
 
-        public void Prepare(RenderTexture source, Material uberMaterial, bool antialiasCoC)
+        bool CheckHistory(int width, int height)
+        {
+            return m_CoCHistory != null && m_CoCHistory.IsCreated() &&
+                m_CoCHistory.width == width && m_CoCHistory.height == height;
+        }
+
+        RenderTextureFormat SelectFormat(RenderTextureFormat primary, RenderTextureFormat secondary)
+        {
+            if (SystemInfo.SupportsRenderTextureFormat(primary)) return primary;
+            if (SystemInfo.SupportsRenderTextureFormat(secondary)) return secondary;
+            return RenderTextureFormat.Default;
+        }
+
+        public void Prepare(RenderTexture source, Material uberMaterial, bool antialiasCoC, Vector2 taaJitter, float taaBlending)
         {
             var settings = model.settings;
+            var colorFormat = RenderTextureFormat.ARGBHalf;
+            var cocFormat = SelectFormat(RenderTextureFormat.R8, RenderTextureFormat.RHalf);
 
             // Material setup
-            var material = context.materialFactory.Get(k_ShaderString);
-            material.shaderKeywords = null;
-
-            var s1 = settings.focusDistance;
             var f = CalculateFocalLength();
-            s1 = Mathf.Max(s1, f);
-            material.SetFloat(Uniforms._Distance, s1);
-
+            var s1 = Mathf.Max(settings.focusDistance, f);
+            var aspect = (float)source.width / source.height;
             var coeff = f * f / (settings.aperture * (s1 - f) * k_FilmHeight * 2);
-            material.SetFloat(Uniforms._LensCoeff, coeff);
-
             var maxCoC = CalculateMaxCoCRadius(source.height);
+
+            var material = context.materialFactory.Get(k_ShaderString);
+            material.SetFloat(Uniforms._Distance, s1);
+            material.SetFloat(Uniforms._LensCoeff, coeff);
             material.SetFloat(Uniforms._MaxCoC, maxCoC);
             material.SetFloat(Uniforms._RcpMaxCoC, 1f / maxCoC);
+            material.SetFloat(Uniforms._RcpAspect, 1f / aspect);
 
-            var rcpAspect = (float)source.height / source.width;
-            material.SetFloat(Uniforms._RcpAspect, rcpAspect);
+            // CoC calculation pass
+            var rtCoC = context.renderTextureFactory.Get(context.width, context.height, 0, cocFormat);
+            Graphics.Blit(null, rtCoC, material, 0);
 
-            var rt1 = context.renderTextureFactory.Get(context.width / 2, context.height / 2, 0, RenderTextureFormat.ARGBHalf);
-            source.filterMode = FilterMode.Point;
-
-            // Pass #1 - Downsampling, prefiltering and CoC calculation
-            if (!antialiasCoC)
+            if (antialiasCoC)
             {
-                Graphics.Blit(source, rt1, material, 0);
-            }
-            else
-            {
-                var initial = m_CoCHistory == null || !m_CoCHistory.IsCreated() || m_CoCHistory.width != context.width / 2 || m_CoCHistory.height != context.height / 2;
+                // CoC temporal filter pass
+                material.SetTexture(Uniforms._CoCTex, rtCoC);
 
-                var tempCoCHistory = RenderTexture.GetTemporary(context.width / 2, context.height / 2, 0, RenderTextureFormat.RHalf);
-                tempCoCHistory.filterMode = FilterMode.Point;
-                tempCoCHistory.name = "CoC History";
+                var blend = CheckHistory(context.width, context.height) ? taaBlending : 0f;
+                material.SetVector(Uniforms._TaaParams, new Vector3(taaJitter.x, taaJitter.y, blend));
 
-                m_MRT[0] = rt1.colorBuffer;
-                m_MRT[1] = tempCoCHistory.colorBuffer;
-                material.SetTexture(Uniforms._MainTex, source);
-                material.SetTexture(Uniforms._HistoryCoC, m_CoCHistory);
-                material.SetFloat(Uniforms._HistoryWeight, initial ? 0 : 0.5f);
-                Graphics.SetRenderTarget(m_MRT, rt1.depthBuffer);
-                GraphicsUtils.Blit(material, 1);
+                var rtFiltered = RenderTexture.GetTemporary(context.width, context.height, 0, cocFormat);
+                Graphics.Blit(m_CoCHistory, rtFiltered, material, 1);
 
-                RenderTexture.ReleaseTemporary(m_CoCHistory);
-                m_CoCHistory = tempCoCHistory;
+                context.renderTextureFactory.Release(rtCoC);
+                if (m_CoCHistory != null) RenderTexture.ReleaseTemporary(m_CoCHistory);
+
+                m_CoCHistory = rtCoC = rtFiltered;
             }
 
-            // Pass #2 - Bokeh simulation
-            var rt2 = context.renderTextureFactory.Get(context.width / 2, context.height / 2, 0, RenderTextureFormat.ARGBHalf);
-            Graphics.Blit(rt1, rt2, material, 2 + (int)settings.kernelSize);
+            // Downsampling and prefiltering pass
+            var rt1 = context.renderTextureFactory.Get(context.width / 2, context.height / 2, 0, colorFormat);
+            material.SetTexture(Uniforms._CoCTex, rtCoC);
+            Graphics.Blit(source, rt1, material, 2);
 
-            // Pass #3 - Postfilter blur
-            Graphics.Blit(rt2, rt1, material, 6);
+            // Bokeh simulation pass
+            var rt2 = context.renderTextureFactory.Get(context.width / 2, context.height / 2, 0, colorFormat);
+            Graphics.Blit(rt1, rt2, material, 3 + (int)settings.kernelSize);
+
+            // Postfilter pass
+            Graphics.Blit(rt2, rt1, material, 7);
+
+            // Give the results to the uber shader.
+            uberMaterial.SetVector(Uniforms._DepthOfFieldParams, new Vector3(s1, coeff, maxCoC));
 
             if (context.profile.debugViews.IsModeActive(DebugMode.FocusPlane))
             {
-                uberMaterial.SetVector(Uniforms._DepthOfFieldParams, new Vector2(s1, coeff));
                 uberMaterial.EnableKeyword("DEPTH_OF_FIELD_COC_VIEW");
                 context.Interrupt();
             }
             else
             {
                 uberMaterial.SetTexture(Uniforms._DepthOfFieldTex, rt1);
+                uberMaterial.SetTexture(Uniforms._DepthOfFieldCoCTex, rtCoC);
                 uberMaterial.EnableKeyword("DEPTH_OF_FIELD");
             }
 
             context.renderTextureFactory.Release(rt2);
-            source.filterMode = FilterMode.Bilinear;
         }
 
         public override void OnDisable()

--- a/PostProcessing/Runtime/Components/TaaComponent.cs
+++ b/PostProcessing/Runtime/Components/TaaComponent.cs
@@ -40,6 +40,8 @@ namespace UnityEngine.PostProcessing
             return DepthTextureMode.Depth | DepthTextureMode.MotionVectors;
         }
 
+        public Vector2 jitterVector { get; private set; }
+
         public void ResetHistory()
         {
             m_ResetHistory = true;
@@ -74,6 +76,8 @@ namespace UnityEngine.PostProcessing
 
             var material = context.materialFactory.Get(k_ShaderString);
             material.SetVector(Uniforms._Jitter, jitter);
+
+            jitterVector = jitter;
         }
 
         public void Render(RenderTexture source, RenderTexture destination)

--- a/PostProcessing/Runtime/PostProcessingBehaviour.cs
+++ b/PostProcessing/Runtime/PostProcessingBehaviour.cs
@@ -232,7 +232,7 @@ namespace UnityEngine.PostProcessing
             if (dofActive)
             {
                 uberActive = true;
-                m_DepthOfField.Prepare(src, uberMaterial, taaActive);
+                m_DepthOfField.Prepare(src, uberMaterial, taaActive, m_Taa.jitterVector, m_Taa.model.settings.taaSettings.motionBlending);
             }
 
             if (m_Bloom.active)


### PR DESCRIPTION
This commit includes major improvements to the temporal filter for DoF. See [the supplemental document](https://goo.gl/3Rpxcz) for details on the improvements.

This commit also includes changes to the other components.

**Changes to the TAA component**

- Added `jitterVector` property to share the current jitter vector with DoF.

**Changes to the Uber shader**

- Changed to use a full-resolution CoC buffer to blend DoF results in the Uber pass. This is needed to eliminate seams and aliasing caused by integration with TAA. This also improves the quality even when TAA is disabled.

**Changes to Common.cginc**

- Added `SEPARATE_TEXTURE_SAMPLER` macro that controls how MainTex is to be declared (sampler2D or separate texture/sampler).

The following is a brief list of the changes on the DoF component.

- Implemented a temporal reprojection filter for the CoC history buffer. It's a simplified variant of the TAA filter and tailored to have nearly-identical characteristics with a minimum cost.

- Changed to use R8 render textures for storing CoC values instead of RHalf. This is needed to compensate performance loss due to increase of the bandwidth usage.

- Changed to utilize the texture gather functions on Shader Model 5.

- Optimized the post blur filter. The sample count was much reduced without losing quality.
