### PR TITLE
Avoid GC allocate in ColorGrading GetCurveTexture

### DIFF
--- a/PostProcessing/Runtime/Components/ColorGradingComponent.cs
+++ b/PostProcessing/Runtime/Components/ColorGradingComponent.cs
@@ -33,8 +33,6 @@ namespace UnityEngine.PostProcessing
         const float k_CurveStep = 1f / k_CurvePrecision;
 
         Texture2D m_GradingCurves;
-
-
         Color[] m_pixels = new Color[k_CurvePrecision * 2];
 
         public override bool active

--- a/PostProcessing/Runtime/Components/ColorGradingComponent.cs
+++ b/PostProcessing/Runtime/Components/ColorGradingComponent.cs
@@ -34,6 +34,9 @@ namespace UnityEngine.PostProcessing
 
         Texture2D m_GradingCurves;
 
+
+        Color[] m_pixels = new Color[k_CurvePrecision * 2];
+
         public override bool active
         {
             get
@@ -236,9 +239,7 @@ namespace UnityEngine.PostProcessing
                 };
             }
 
-            var pixels = new Color[k_CurvePrecision * 2];
             var curves = model.settings.curves;
-
             curves.hueVShue.Cache();
             curves.hueVSsat.Cache();
 
@@ -251,17 +252,17 @@ namespace UnityEngine.PostProcessing
                 float y = curves.hueVSsat.Evaluate(t);
                 float z = curves.satVSsat.Evaluate(t);
                 float w = curves.lumVSsat.Evaluate(t);
-                pixels[i] = new Color(x, y, z, w);
+                m_pixels[i] = new Color(x, y, z, w);
 
                 // YRGB
                 float m = curves.master.Evaluate(t);
                 float r = curves.red.Evaluate(t);
                 float g = curves.green.Evaluate(t);
                 float b = curves.blue.Evaluate(t);
-                pixels[i + k_CurvePrecision] = new Color(r, g, b, m);
+                m_pixels[i + k_CurvePrecision] = new Color(r, g, b, m);
             }
 
-            m_GradingCurves.SetPixels(pixels);
+            m_GradingCurves.SetPixels(m_pixels);
             m_GradingCurves.Apply(false, false);
 
             return m_GradingCurves;


### PR DESCRIPTION
# Before
PostProcessing allocate 4KB GC in every frame by ColorGrading Component.
![beforepp](https://cloud.githubusercontent.com/assets/1110795/24793701/ff50a9f8-1bbd-11e7-81e1-d9f5b130062e.PNG)

# After
zero allocate in every frame.
![afterpp](https://cloud.githubusercontent.com/assets/1110795/24793771/387320c6-1bbe-11e7-8440-57229c30a29c.PNG)

* This GC Allocate is not necessary important in normal use. But it is important when use PostProcessing Controller.