### PR TITLE
Force alpha to 1 after FXAA

### DIFF
--- a/PostProcessing/Resources/Shaders/FXAA.shader
+++ b/PostProcessing/Resources/Shaders/FXAA.shader
@@ -63,7 +63,7 @@ Shader "Hidden/Post FX/FXAA"
 
             color.rgb = UberSecondPass(color.rgb, i.uv);
 
-            return color;
+            return half4(color.rgb, 1.0);
         }
 
     ENDCG


### PR DESCRIPTION
FXAA stores luma info in alpha, when rendering to a RT used as a texture in UI it messes up everything. See #159.