### PR TITLE
Attribute fix

### DIFF
--- a/PostProcessing/Runtime/Effects/DepthOfField.cs
+++ b/PostProcessing/Runtime/Effects/DepthOfField.cs
@@ -14,7 +14,7 @@ namespace UnityEngine.Experimental.PostProcessing
     public sealed class KernelSizeParameter : ParameterOverride<KernelSize> {}
 
     [Serializable]
-    [PostProcess(typeof(DepthOfFieldRenderer), "Unity/Depth of Field")]
+    [PostProcess(typeof(DepthOfFieldRenderer), "Unity/Depth of Field", false)]
     public sealed class DepthOfField : PostProcessEffectSettings
     {
         [Min(0.1f), Tooltip("Distance to the point of focus.")]


### PR DESCRIPTION
Refactored RenderEffect() to make the allowInSceneView attribute argument work for depth of field and motion blur.

Disabled depth of field in the scene view.

(For TAA to use the same path, it needs to become a PostProcessEffectRenderer. I'm guessing that's the plan, no?)