### PR TITLE
Fixed color grading issues on low-end mobiles

### DIFF
--- a/PostProcessing/Runtime/Components/ColorGradingComponent.cs
+++ b/PostProcessing/Runtime/Components/ColorGradingComponent.cs
@@ -223,11 +223,19 @@ namespace UnityEngine.PostProcessing
             outOffset = GetOffsetValue(offset);
         }
 
+        TextureFormat GetCurveFormat()
+        {
+            if (SystemInfo.SupportsTextureFormat(TextureFormat.RGBAHalf))
+                return TextureFormat.RGBAHalf;
+
+            return TextureFormat.RGBA32;
+        }
+
         Texture2D GetCurveTexture()
         {
             if (m_GradingCurves == null)
             {
-                m_GradingCurves = new Texture2D(k_CurvePrecision, 2, TextureFormat.RGBAHalf, false, true)
+                m_GradingCurves = new Texture2D(k_CurvePrecision, 2, GetCurveFormat(), false, true)
                 {
                     name = "Internal Curves Texture",
                     hideFlags = HideFlags.DontSave,
@@ -271,6 +279,14 @@ namespace UnityEngine.PostProcessing
             return lut != null && lut.IsCreated() && lut.height == k_InternalLogLutSize;
         }
 
+        RenderTextureFormat GetLutFormat()
+        {
+            if (SystemInfo.SupportsRenderTextureFormat(RenderTextureFormat.ARGBHalf))
+                return RenderTextureFormat.ARGBHalf;
+
+            return RenderTextureFormat.ARGB32;
+        }
+
         void GenerateLut()
         {
             var settings = model.settings;
@@ -279,7 +295,7 @@ namespace UnityEngine.PostProcessing
             {
                 GraphicsUtils.Destroy(model.bakedLut);
 
-                model.bakedLut = new RenderTexture(k_InternalLogLutSize * k_InternalLogLutSize, k_InternalLogLutSize, 0, RenderTextureFormat.ARGBHalf)
+                model.bakedLut = new RenderTexture(k_InternalLogLutSize * k_InternalLogLutSize, k_InternalLogLutSize, 0, GetLutFormat())
                 {
                     name = "Color Grading Log LUT",
                     hideFlags = HideFlags.DontSave,


### PR DESCRIPTION
... at the expense of visual quality. This fix should work for all mobiles without proper half/float texture support.

At this point this is more of a bandage than a true solution because v1 was made with HDR in mind. V2 handles this in a much better way by separating LDR and HDR grading properly. Sadly, doing so in V1 would require a rewrite of a good chunk of the Color Grading effect and would potentially break compatibility (no-no).