### PR TITLE
fix dx9 shader model 3 linear rendering DoF bug

### DIFF
--- a/PostProcessing/Runtime/Components/DepthOfFieldComponent.cs
+++ b/PostProcessing/Runtime/Components/DepthOfFieldComponent.cs
@@ -105,7 +105,6 @@ namespace UnityEngine.PostProcessing
             material.SetFloat(Uniforms._RcpAspect, 1f / aspect);
 
             // CoC calculation pass
-			// HACK by hdh, add RenderTextureReadWrite.Linear setting. in DX9 shader model 3 Linear rendering, without this will have bug
             var rtCoC = context.renderTextureFactory.Get(context.width, context.height, 0, cocFormat, RenderTextureReadWrite.Linear);
             Graphics.Blit(null, rtCoC, material, 0);
 

--- a/PostProcessing/Runtime/Components/DepthOfFieldComponent.cs
+++ b/PostProcessing/Runtime/Components/DepthOfFieldComponent.cs
@@ -105,7 +105,8 @@ namespace UnityEngine.PostProcessing
             material.SetFloat(Uniforms._RcpAspect, 1f / aspect);
 
             // CoC calculation pass
-            var rtCoC = context.renderTextureFactory.Get(context.width, context.height, 0, cocFormat);
+			// HACK by hdh, add RenderTextureReadWrite.Linear setting. in DX9 shader model 3 Linear rendering, without this will have bug
+            var rtCoC = context.renderTextureFactory.Get(context.width, context.height, 0, cocFormat, RenderTextureReadWrite.Linear);
             Graphics.Blit(null, rtCoC, material, 0);
 
             if (antialiasCoC)

--- a/PostProcessing/Runtime/Utils/RenderTextureFactory.cs
+++ b/PostProcessing/Runtime/Utils/RenderTextureFactory.cs
@@ -27,7 +27,7 @@ namespace UnityEngine.PostProcessing
 
         public RenderTexture Get(int width, int height, int depthBuffer = 0, RenderTextureFormat format = RenderTextureFormat.ARGBHalf, RenderTextureReadWrite rw = RenderTextureReadWrite.Default, FilterMode filterMode = FilterMode.Bilinear, TextureWrapMode wrapMode = TextureWrapMode.Clamp, string name = "FactoryTempTexture")
         {
-            var rt = RenderTexture.GetTemporary(width, height, depthBuffer, format);
+            var rt = RenderTexture.GetTemporary(width, height, depthBuffer, format, rw); // add forgotten param rw
             rt.filterMode = filterMode;
             rt.wrapMode = wrapMode;
             rt.name = name;


### PR DESCRIPTION
Under d3d9, shader model 3, linear rendering, DoF has a bug to read R8 coc render target, maybe write as linear, read as SRGB. this commit force RenderTextureReadWrite.Linear param when create R8 render target to solve this.