### PR TITLE
Feature: Use child colliders

### DIFF
--- a/PostProcessing/Editor/PostProcessVolumeEditor.cs
+++ b/PostProcessing/Editor/PostProcessVolumeEditor.cs
@@ -11,6 +11,7 @@ namespace UnityEditor.Rendering.PostProcessing
 
         SerializedProperty m_IsGlobal;
         SerializedProperty m_BlendRadius;
+		SerializedProperty m_UseChildColliders;
         SerializedProperty m_Weight;
         SerializedProperty m_Priority;
 
@@ -22,6 +23,7 @@ namespace UnityEditor.Rendering.PostProcessing
 
             m_IsGlobal = FindProperty(x => x.isGlobal);
             m_BlendRadius = FindProperty(x => x.blendDistance);
+			m_UseChildColliders = FindProperty (x => x.useChildColliders);
             m_Weight = FindProperty(x => x.weight);
             m_Priority = FindProperty(x => x.priority);
 
@@ -48,8 +50,11 @@ namespace UnityEditor.Rendering.PostProcessing
 
             EditorGUILayout.PropertyField(m_IsGlobal);
 
-            if (!m_IsGlobal.boolValue) // Blend radius is not needed for global volumes
-                EditorGUILayout.PropertyField(m_BlendRadius);
+			if (!m_IsGlobal.boolValue)
+			{ // Blend radius is not needed for global volumes
+				EditorGUILayout.PropertyField (m_BlendRadius);
+				EditorGUILayout.PropertyField (m_UseChildColliders);
+			}
             
             EditorGUILayout.PropertyField(m_Weight);
             EditorGUILayout.PropertyField(m_Priority);

--- a/PostProcessing/Runtime/PostProcessManager.cs
+++ b/PostProcessing/Runtime/PostProcessManager.cs
@@ -130,7 +130,12 @@ namespace UnityEngine.Rendering.PostProcessing
 
                     // If volume isn't global and has no collider, skip it as it's useless
                     var colliders = m_TempColliders;
-                    volume.GetComponents(colliders);
+                    
+					if (volume.useChildColliders)
+						volume.GetComponentsInChildren (colliders);
+					else
+						volume.GetComponents(colliders);
+
                     if (colliders.Count == 0)
                         continue;
 
@@ -322,8 +327,13 @@ namespace UnityEngine.Rendering.PostProcessing
 
                     // If volume isn't global and has no collider, skip it as it's useless
                     var colliders = m_TempColliders;
-                    volume.GetComponents(colliders);
-                    if (colliders.Count == 0)
+
+					if (volume.useChildColliders)
+						volume.GetComponentsInChildren (colliders);
+					else
+	                    volume.GetComponents(colliders);
+                    
+					if (colliders.Count == 0)
                         continue;
 
                     // Find closest distance to volume, 0 means it's inside it

--- a/PostProcessing/Runtime/PostProcessVolume.cs
+++ b/PostProcessing/Runtime/PostProcessVolume.cs
@@ -178,15 +178,20 @@ namespace UnityEngine.Rendering.PostProcessing
             }
 #endif
 
-            var scale = transform.localScale;
-            var invScale = new Vector3(1f / scale.x, 1f / scale.y, 1f / scale.z);
-            Gizmos.matrix = Matrix4x4.TRS(transform.position, transform.rotation, scale);
+           // var scale = transform.localScale;
+           // var invScale = new Vector3(1f / scale.x, 1f / scale.y, 1f / scale.z);
+            //Gizmos.matrix = Matrix4x4.TRS(transform.position, transform.rotation, scale);
 
             // Draw a separate gizmo for each collider
             foreach (var collider in colliders)
             {
                 if (!collider.enabled)
                     continue;
+
+				var pos = collider.transform.position;
+				var lossyScale = collider.transform.lossyScale;
+				var scale = transform.localScale;
+				var invScale = new Vector3(1f / scale.x, 1f / scale.y, 1f / scale.z);
 
                 // We'll just use scaling as an approximation for volume skin. It's far from being
                 // correct (and is completely wrong in some cases). Ultimately we'd use a distance
@@ -200,8 +205,9 @@ namespace UnityEngine.Rendering.PostProcessing
                 if (type == typeof(BoxCollider))
                 {
                     var c = (BoxCollider)collider;
-                    Gizmos.DrawCube(c.center, c.size);
-                    Gizmos.DrawWireCube(c.center, c.size + invScale * blendDistance * 4f);
+
+					Gizmos.DrawCube(pos + Vector3.Scale(c.center, scale), Vector3.Scale(lossyScale, c.size));
+                  //  Gizmos.DrawWireCube(c.center, c.size + invScale * blendDistance * 4f);
                 }
                 else if (type == typeof(SphereCollider))
                 {

--- a/PostProcessing/Runtime/PostProcessVolume.cs
+++ b/PostProcessing/Runtime/PostProcessVolume.cs
@@ -178,20 +178,15 @@ namespace UnityEngine.Rendering.PostProcessing
             }
 #endif
 
-           // var scale = transform.localScale;
-           // var invScale = new Vector3(1f / scale.x, 1f / scale.y, 1f / scale.z);
-            //Gizmos.matrix = Matrix4x4.TRS(transform.position, transform.rotation, scale);
-
             // Draw a separate gizmo for each collider
             foreach (var collider in colliders)
             {
                 if (!collider.enabled)
                     continue;
 
-				var pos = collider.transform.position;
-				var lossyScale = collider.transform.lossyScale;
-				var scale = transform.localScale;
+				var scale = collider.transform.lossyScale;
 				var invScale = new Vector3(1f / scale.x, 1f / scale.y, 1f / scale.z);
+				Gizmos.matrix = Matrix4x4.TRS(collider.transform.position, collider.transform.rotation, scale);
 
                 // We'll just use scaling as an approximation for volume skin. It's far from being
                 // correct (and is completely wrong in some cases). Ultimately we'd use a distance
@@ -206,8 +201,8 @@ namespace UnityEngine.Rendering.PostProcessing
                 {
                     var c = (BoxCollider)collider;
 
-					Gizmos.DrawCube(pos + Vector3.Scale(c.center, scale), Vector3.Scale(lossyScale, c.size));
-                  //  Gizmos.DrawWireCube(c.center, c.size + invScale * blendDistance * 4f);
+					Gizmos.DrawCube(c.center, c.size);
+                	Gizmos.DrawWireCube(c.center, c.size + invScale * blendDistance * 4f);
                 }
                 else if (type == typeof(SphereCollider))
                 {

--- a/PostProcessing/Runtime/PostProcessVolume.cs
+++ b/PostProcessing/Runtime/PostProcessVolume.cs
@@ -65,6 +65,9 @@ namespace UnityEngine.Rendering.PostProcessing
         [Min(0f), Tooltip("Outer distance to start blending from. A value of 0 means no blending and the volume overrides will be applied immediatly upon entry.")]
         public float blendDistance = 0f;
 
+		[Tooltip("Should volumes be calculated based on colliders from children objects as well?")]
+		public bool useChildColliders = false;
+
         [Range(0f, 1f), Tooltip("Total weight of this volume in the scene. 0 means it won't do anything, 1 means full effect.")]
         public float weight = 1f;
         
@@ -156,7 +159,11 @@ namespace UnityEngine.Rendering.PostProcessing
         void OnDrawGizmos()
         {
             var colliders = m_TempColliders;
-            GetComponents(colliders);
+
+			if (useChildColliders)
+				GetComponentsInChildren (colliders);
+			else
+            	GetComponents(colliders);
 
             if (isGlobal || colliders == null)
                 return;


### PR DESCRIPTION
I added the ability to use children objects and have their colliders apply to the post processing volume. I also added the required Inspector toggle and gizmo functionality. This is very useful as it allows you to more easily place volumes by moving game objects around instead of moving the center points of colliders. Additionally, you can now rotate colliders by rotating the child game objects. Finally, you can also more easily organize and label the parts of your volume as the colliders are components on separate game objects. 

![unity_2017-07-31_17-19-00](https://user-images.githubusercontent.com/3311369/28798970-7ef461f8-7614-11e7-8006-be8c9a0338e6.png)