### PR TITLE
Fixed #234

### DIFF
--- a/PostProcessing/Resources/Shaders/LutGen.shader
+++ b/PostProcessing/Resources/Shaders/LutGen.shader
@@ -74,8 +74,9 @@ Shader "Hidden/Post FX/Lut Generator"
 
         #elif TONEMAPPING_NEUTRAL
 
-            color = ACEScg_to_unity(acescg);
+            color = ACEScg_to_ACES(acescg);
             color = NeutralTonemap(color, _NeutralTonemapperParams1, _NeutralTonemapperParams2);
+            color = ACES_to_unity(color);
 
         #else
 


### PR DESCRIPTION
See the linked issue for more information.

This fix affects the output of the neutral tonemapper slightly which means that anyone who relied on this tonemapper until now and tweaked color grading to match what they needed won't see the exact same result after updating... That said, the fix also makes the highlights look much better when the neutral tonemapper is in use.