### PR TITLE
Use non-deprecated EventTypes

### DIFF
--- a/PostProcessing/Editor/Utils/CurveEditor.cs
+++ b/PostProcessing/Editor/Utils/CurveEditor.cs
@@ -388,7 +388,7 @@ namespace UnityEditor.Rendering.PostProcessing
                 // Draw
                 if (state.editable || state.showNonEditableHandles)
                 {
-                    if (e.type == EventType.repaint)
+                    if (e.type == EventType.Repaint)
                     {
                         var selectedColor = (isCurrentlySelectedCurve && isCurrentlySelectedKeyframe)
                             ? settings.selectionColor
@@ -434,7 +434,7 @@ namespace UnityEditor.Rendering.PostProcessing
                     }
 
                     // Keyframe selection & context menu
-                    if (e.type == EventType.mouseDown && rect.Contains(e.mousePosition))
+                    if (e.type == EventType.MouseDown && rect.Contains(e.mousePosition))
                     {
                         if (hitRect.Contains(e.mousePosition))
                         {
@@ -465,7 +465,7 @@ namespace UnityEditor.Rendering.PostProcessing
                     }
 
                     // Tangent selection & edit mode
-                    if (e.type == EventType.mouseDown && rect.Contains(e.mousePosition))
+                    if (e.type == EventType.MouseDown && rect.Contains(e.mousePosition))
                     {
                         if (inTangentHitRect.Contains(e.mousePosition) && (k > 0 || state.loopInBounds))
                         {
@@ -511,7 +511,7 @@ namespace UnityEditor.Rendering.PostProcessing
             var e = Event.current;
 
             // Selection
-            if (e.type == EventType.mouseDown)
+            if (e.type == EventType.MouseDown)
             {
                 GUI.FocusControl(null);
                 m_SelectedCurve = null;
@@ -594,7 +594,7 @@ namespace UnityEditor.Rendering.PostProcessing
             }
 
             // Delete selected key(s)
-            if (e.type == EventType.keyDown && (e.keyCode == KeyCode.Delete || e.keyCode == KeyCode.Backspace))
+            if (e.type == EventType.KeyDown && (e.keyCode == KeyCode.Delete || e.keyCode == KeyCode.Backspace))
             {
                 if (m_SelectedKeyframeIndex != -1 && m_SelectedCurve != null)
                 {


### PR DESCRIPTION
2017.3 complains about some deprecated EventTypes used.  The 'correct' versions have long been available (at least 5.4), so it is safe to switch over.