### PR TITLE
Fixes for Xbox One support

### DIFF
--- a/PostProcessing/Runtime/Utils/RuntimeUtilities.cs
+++ b/PostProcessing/Runtime/Utils/RuntimeUtilities.cs
@@ -240,6 +240,8 @@ namespace UnityEngine.Rendering.PostProcessing
             {
 #if UNITY_EDITOR
                 return UnityEditor.PlayerSettings.virtualRealitySupported;
+#elif UNITY_XBOXONE
+                return false;
 #elif UNITY_2017_2_OR_NEWER
                 return UnityEngine.XR.XRSettings.enabled;
 #elif UNITY_5_6_OR_NEWER

--- a/PostProcessing/Shaders/API/XboxOne.hlsl
+++ b/PostProcessing/Shaders/API/XboxOne.hlsl
@@ -1,4 +1,4 @@
-#define UNITY_UV_STARTS_AT_TOP 0 // Probably wrong?
+#define UNITY_UV_STARTS_AT_TOP 1
 #define UNITY_REVERSED_Z 1
 #define UNITY_GATHER_SUPPORTED (SHADER_TARGET >= 50)
 


### PR DESCRIPTION
- The Xbox One player doesn't have UnityEngine.VR(XR).* classes. References to them should be excluded when building.
- Fix for the vertical flipping issue.