### PR TITLE
Reset jitted camera property on disable.

### DIFF
--- a/PostProcessing/Runtime/Components/TaaComponent.cs
+++ b/PostProcessing/Runtime/Components/TaaComponent.cs
@@ -208,6 +208,9 @@ namespace UnityEngine.PostProcessing
             if (m_HistoryTexture != null)
                 RenderTexture.ReleaseTemporary(m_HistoryTexture);
 
+#if UNITY_5_5_OR_NEWER
+            context.camera.useJitteredProjectionMatrixForTransparentRendering = true;
+#endif
             m_HistoryTexture = null;
             m_SampleIndex = 0;
             ResetHistory();


### PR DESCRIPTION
Fix for https://github.com/Unity-Technologies/PostProcessing/issues/293

The `useJitteredProjectionMatrixForTransparentRendering` is set to `false`, but never returned to `true`

This change sets the value to true in the OnDisable. I'm not 100% sure its the most correct place to do this, but it does solve the issue. 