### PR TITLE
XR Support for TAA (fixes)

### DIFF
--- a/PostProcessing/Editor/PostProcessLayerEditor.cs
+++ b/PostProcessing/Editor/PostProcessLayerEditor.cs
@@ -206,7 +206,7 @@ namespace UnityEditor.Rendering.PostProcessing
                 if (m_AntialiasingMode.intValue == (int)PostProcessLayer.Antialiasing.TemporalAntialiasing)
                 {
                     if (RuntimeUtilities.isSinglePassStereoEnabled)
-                        EditorGUILayout.HelpBox("TAA doesn't work with Single-pass stereo rendering.", MessageType.Warning);
+                        EditorGUILayout.HelpBox("TAA requires Unity 2017.3+ for Single-pass stereo rendering support.", MessageType.Warning);
 
                     EditorGUILayout.PropertyField(m_TaaJitterSpread);
                     EditorGUILayout.PropertyField(m_TaaStationaryBlending);

--- a/PostProcessing/Runtime/PostProcessLayer.cs
+++ b/PostProcessing/Runtime/PostProcessLayer.cs
@@ -5,6 +5,12 @@ using UnityEngine.Assertions;
 
 namespace UnityEngine.Rendering.PostProcessing
 {
+#if UNITY_2017_2_OR_NEWER
+    using XRSettings = UnityEngine.XR.XRSettings;
+#elif UNITY_5_6_OR_NEWER
+    using XRSettings = UnityEngine.VR.VRSettings;
+#endif
+
     // TODO: XMLDoc everything (?)
     [DisallowMultipleComponent, ExecuteInEditMode, ImageEffectAllowedInSceneView]
     [AddComponentMenu("Rendering/Post-process Layer", -1)]
@@ -266,7 +272,8 @@ namespace UnityEngine.Rendering.PostProcessing
             // is switched off and the FOV or any other camera property changes.
             m_Camera.ResetProjectionMatrix();
             m_Camera.nonJitteredProjectionMatrix = m_Camera.projectionMatrix;
-            if (XR.XRSettings.isDeviceActive)
+
+            if (XRSettings.isDeviceActive)
                 m_Camera.ResetStereoProjectionMatrices();
 
             BuildCommandBuffers();
@@ -401,10 +408,9 @@ namespace UnityEngine.Rendering.PostProcessing
             {
                 m_Camera.ResetProjectionMatrix();
 
-                if (XR.XRSettings.isDeviceActive)
+                if (XRSettings.isDeviceActive)
                 {
-                    if (m_CurrentContext.xrSinglePass ||
-                        (m_Camera.stereoActiveEye == Camera.MonoOrStereoscopicEye.Right))
+                    if (RuntimeUtilities.isSinglePassStereoEnabled || m_Camera.stereoActiveEye == Camera.MonoOrStereoscopicEye.Right)
                         m_Camera.ResetStereoProjectionMatrices();
                 }
             }
@@ -589,14 +595,16 @@ namespace UnityEngine.Rendering.PostProcessing
             {
                 if (!RuntimeUtilities.scriptableRenderPipelineActive)
                 {
-                    if (XR.XRSettings.isDeviceActive)
+                    if (XRSettings.isDeviceActive)
                     {
                         // We only need to configure all of this once for stereo, during OnPreCull
                         if (context.camera.stereoActiveEye != Camera.MonoOrStereoscopicEye.Right)
                             temporalAntialiasing.ConfigureStereoJitteredProjectionMatrices(context);
                     }
                     else
+                    {
                         temporalAntialiasing.ConfigureJitteredProjectionMatrix(context);
+                    }
                 }
 
                 var taaTarget = m_TargetPool.Get();

--- a/PostProcessing/Runtime/PostProcessRenderContext.cs
+++ b/PostProcessing/Runtime/PostProcessRenderContext.cs
@@ -1,5 +1,11 @@
 namespace UnityEngine.Rendering.PostProcessing
 {
+#if UNITY_2017_2_OR_NEWER
+    using XRSettings = UnityEngine.XR.XRSettings;
+#elif UNITY_5_6_OR_NEWER
+    using XRSettings = UnityEngine.VR.VRSettings;
+#endif
+
     // Context object passed around all post-fx in a frame
     public sealed class PostProcessRenderContext
     {
@@ -7,36 +13,36 @@ namespace UnityEngine.Rendering.PostProcessing
         // The following should be filled by the render pipeline
 
         // Camera currently rendering
-        private Camera m_camera;
+        Camera m_Camera;
         public Camera camera
         {
-            get
-            {
-                return this.m_camera;
-            }
-
+            get { return m_Camera; }
             set
             {
-                this.m_camera = value;
+                m_Camera = value;
 
-                if (XR.XRSettings.isDeviceActive)
+                if (XRSettings.isDeviceActive)
                 {
-                    RenderTextureDescriptor xrDesc = XR.XRSettings.eyeTextureDesc;
-                    m_width = xrDesc.width;
-                    m_height = xrDesc.height;
-
-                    m_xrSinglePass = (xrDesc.vrUsage == VRTextureUsage.TwoEyes);
+#if UNITY_2017_2_OR_NEWER
+                    RenderTextureDescriptor xrDesc = XRSettings.eyeTextureDesc;
+                    width = xrDesc.width;
+                    height = xrDesc.height;
+#else
+                    width = m_Camera.pixelWidth * 2;
+                    height = m_Camera.pixelHeight;
+#endif
 
                     if (camera.stereoActiveEye == Camera.MonoOrStereoscopicEye.Right)
-                        m_xrActiveEye = (int)Camera.StereoscopicEye.Right;
+                        xrActiveEye = (int)Camera.StereoscopicEye.Right;
 
-                    m_xrSingleEyeWidth = XR.XRSettings.eyeTextureWidth;
+                    xrSingleEyeWidth = XRSettings.eyeTextureWidth;
+                    xrSingleEyeHeight = XRSettings.eyeTextureHeight;
                 }
                 else
                 {
-                    m_width = m_camera.pixelWidth;
-                    m_height = m_camera.pixelHeight;
-                    m_xrSingleEyeWidth = m_width;
+                    width = m_Camera.pixelWidth;
+                    height = m_Camera.pixelHeight;
+                    xrSingleEyeWidth = width;
                 }
             }
         }
@@ -78,39 +84,19 @@ namespace UnityEngine.Rendering.PostProcessing
         public PostProcessDebugLayer debugLayer { get; internal set; }
 
         // Current camera width in pixels
-        private int m_width;
-        public int width
-        {
-            get { return m_width; }
-        }
+        public int width { get; private set; }
 
         // Current camera height in pixels
-        private int m_height;
-        public int height
-        {
-            get { return m_height; }
-        }
-
-        // Is XR running in single-pass stereo mode?
-        private bool m_xrSinglePass;
-        public bool xrSinglePass
-        {
-            get { return m_xrSinglePass; }
-        }
+        public int height { get; private set; }
 
         // Current active rendering eye (for XR)
-        private int m_xrActiveEye;
-        public int xrActiveEye
-        {
-            get { return m_xrActiveEye; }
-        }
+        public int xrActiveEye { get; private set; }
 
         // Current single eye width in pixels (for XR)
-        private int m_xrSingleEyeWidth;
-        public int singleEyeWidth
-        {
-            get { return m_xrSingleEyeWidth; }
-        }
+        public int xrSingleEyeWidth { get; private set; }
+
+        // Current single eye height in pixels (for XR)
+        public int xrSingleEyeHeight { get; private set; }
 
         // Are we currently rendering in the scene view?
         public bool isSceneView { get; internal set; }
@@ -124,13 +110,13 @@ namespace UnityEngine.Rendering.PostProcessing
 
         public void Reset()
         {
-            m_camera = null;
-            m_width = 0;
-            m_height = 0;
+            m_Camera = null;
+            width = 0;
+            height = 0;
 
-            m_xrSinglePass = false;
-            m_xrActiveEye = (int)Camera.StereoscopicEye.Left;
-            m_xrSingleEyeWidth = 0;
+            xrActiveEye = (int)Camera.StereoscopicEye.Left;
+            xrSingleEyeWidth = 0;
+            xrSingleEyeHeight = 0;
 
             command = null;
             source = 0;

--- a/PostProcessing/Runtime/Utils/RuntimeUtilities.cs
+++ b/PostProcessing/Runtime/Utils/RuntimeUtilities.cs
@@ -232,6 +232,8 @@ namespace UnityEngine.Rendering.PostProcessing
                 return UnityEditor.PlayerSettings.virtualRealitySupported
                     && UnityEditor.PlayerSettings.stereoRenderingPath == UnityEditor.StereoRenderingPath.SinglePass
                     && Application.isPlaying;
+#elif UNITY_2017_2_OR_NEWER
+                return UnityEngine.XRSettings.eyeTextureDesc.vrUsage == VRTextureUsage.TwoEyes;
 #else
                 return false;
 #endif
@@ -408,13 +410,14 @@ namespace UnityEngine.Rendering.PostProcessing
 
         public static Matrix4x4 GenerateJitteredProjectionMatrixFromOriginal(PostProcessRenderContext context, Matrix4x4 origProj, Vector2 jitter)
         {
-            FrustumPlanes planes = origProj.decomposeProjection;
+#if UNITY_2017_2_OR_NEWER
+            var planes = origProj.decomposeProjection;
 
             float vertFov = Math.Abs(planes.top) + Math.Abs(planes.bottom);
             float horizFov = Math.Abs(planes.left) + Math.Abs(planes.right);
 
-            var planeJitter = new Vector2(jitter.x * horizFov / context.singleEyeWidth,
-                                            jitter.y * vertFov / context.height);
+            var planeJitter = new Vector2(jitter.x * horizFov / context.xrSingleEyeWidth,
+                                          jitter.y * vertFov / context.height);
 
             planes.left += planeJitter.x;
             planes.right += planeJitter.x;
@@ -424,6 +427,9 @@ namespace UnityEngine.Rendering.PostProcessing
             var jitteredMatrix = Matrix4x4.Frustum(planes);
 
             return jitteredMatrix;
+#endif
+
+            return origProj;
         }
 
         #endregion


### PR DESCRIPTION
- Fixed compatibility with 5.6 and 2017.1 (TAA won't work there but at least it compiles).
- Cleaned up the RenderContext class to use auto getter/setter.
- Changed TAA tooltip when VR is enabled.
- Auto-formatting and code conventions.