### PR TITLE
Fix shadowmap jitter issues with TAA.

### DIFF
--- a/PostProcessing/Runtime/Effects/TemporalAntialiasing.cs
+++ b/PostProcessing/Runtime/Effects/TemporalAntialiasing.cs
@@ -69,9 +69,11 @@ namespace UnityEngine.Rendering.PostProcessing
 
         Vector2 GenerateRandomOffset()
         {
+            // The variance between 0 and the actual halton sequence values reveals noticeable instability
+            // in Unity's shadow maps, so we avoid index 0.
             var offset = new Vector2(
-                    HaltonSeq.Get(m_SampleIndex & 1023, 2),
-                    HaltonSeq.Get(m_SampleIndex & 1023, 3)
+                    HaltonSeq.Get((m_SampleIndex & 1023) + 1, 2) - 0.5f,
+                    HaltonSeq.Get((m_SampleIndex & 1023) + 1, 3) - 0.5f
                 );
 
             if (++m_SampleIndex >= k_SampleCount)


### PR DESCRIPTION
With TAA enabled, Unity's shadows have a noticeable jitter every few frames in certain circumstances (especially with the Stable shadow map fit setting).

I tracked it down to the halton sequence values used for the jitter offset. Every `k_SampleCount` frames, it passes 0 in as the index argument to the halton sequence function. But I don't think 0 is really a 'true' halton sequence value and it just sets the jitter offset vector to `(0, 0)` which is a bit far away from the rest of the offset vectors (everything is still within [0, 1] though).

The difference in that (0, 0) jitter vector compared to the other ones seems to reveal instability in Unity's shadow mapping in some circumstances.

Changing the indices passed to the halton sequence to be 1-based instead of 0-based fixes the shadow jitter for me. Playdead's TAA implementation does the same thing.

I also changed the jitter offset vector to offset the camera in the range of [-0.5, 0.5] instead of [0, 1] since that made more sense to me. I noticed the grain effect passes 0-based index values to the halton sequence generator as well but I haven't investigated whether that's a noticeable problem or not. V1's TAA has the same issue too.

---

I have a small test project which demonstrates the shadow jitter problem, but it uses a (free from the Asset Store) SpeedTree asset so I'm not sure about the legal implications of distributing it publicly.


