### PR TITLE
Fix bloom texture

### DIFF
--- a/PostProcessing/Runtime/Effects/Bloom.cs
+++ b/PostProcessing/Runtime/Effects/Bloom.cs
@@ -120,7 +120,7 @@ namespace UnityEngine.Rendering.PostProcessing
             int qualityOffset = settings.mobileOptimized ? 1 : 0;
 
             // Downsample
-            var last = context.source;
+            var lastDown = context.source;
             for (int i = 0; i < iterations; i++)
             {
                 int mipDown = m_Pyramid[i].down;
@@ -131,22 +131,22 @@ namespace UnityEngine.Rendering.PostProcessing
 
                 cmd.GetTemporaryRT(mipDown, tw, th, 0, FilterMode.Bilinear, context.sourceFormat);
                 cmd.GetTemporaryRT(mipUp, tw, th, 0, FilterMode.Bilinear, context.sourceFormat);
-                cmd.BlitFullscreenTriangle(last, mipDown, sheet, pass);
+                cmd.BlitFullscreenTriangle(lastDown, mipDown, sheet, pass);
 
-                last = mipDown;
+                lastDown = mipDown;
                 tw = Mathf.Max(tw / 2, 1);
                 th = Mathf.Max(th / 2, 1);
             }
 
             // Upsample
-            last = m_Pyramid[iterations - 1].down;
+            int lastUp = m_Pyramid[iterations - 1].down;
             for (int i = iterations - 2; i >= 0; i--)
             {
                 int mipDown = m_Pyramid[i].down;
                 int mipUp = m_Pyramid[i].up;
                 cmd.SetGlobalTexture(ShaderIDs.BloomTex, mipDown);
-                cmd.BlitFullscreenTriangle(last, mipUp, sheet, (int)Pass.UpsampleTent + qualityOffset);
-                last = mipUp;
+                cmd.BlitFullscreenTriangle(lastUp, mipUp, sheet, (int)Pass.UpsampleTent + qualityOffset);
+                lastUp = mipUp;
             }
 
             var linearColor = settings.color.value.linear;
@@ -193,16 +193,20 @@ namespace UnityEngine.Rendering.PostProcessing
             uberSheet.properties.SetVector(ShaderIDs.Bloom_Settings, shaderSettings);
             uberSheet.properties.SetColor(ShaderIDs.Bloom_Color, linearColor);
             uberSheet.properties.SetTexture(ShaderIDs.Bloom_DirtTex, dirtTexture);
-            cmd.SetGlobalTexture(ShaderIDs.BloomTex, m_Pyramid[0].up);
+            cmd.SetGlobalTexture(ShaderIDs.BloomTex, lastUp);
 
             // Cleanup
             for (int i = 0; i < iterations; i++)
             {
-                cmd.ReleaseTemporaryRT(m_Pyramid[i].down);
-                cmd.ReleaseTemporaryRT(m_Pyramid[i].up);
+                if (m_Pyramid[i].down != lastUp)
+                    cmd.ReleaseTemporaryRT(m_Pyramid[i].down);
+                if (m_Pyramid[i].up != lastUp)
+                    cmd.ReleaseTemporaryRT(m_Pyramid[i].up);
             }
 
             cmd.EndSample("BloomPyramid");
+
+            context.bloomTemporaryRT = lastUp;
         }
     }
 }

--- a/PostProcessing/Runtime/PostProcessLayer.cs
+++ b/PostProcessing/Runtime/PostProcessLayer.cs
@@ -766,6 +766,7 @@ namespace UnityEngine.Rendering.PostProcessing
             uberSheet.properties.Clear();
             context.uberSheet = uberSheet;
             context.autoExposureTexture = RuntimeUtilities.whiteTexture;
+            context.bloomTemporaryRT = -1;
 
             var cmd = context.command;
             cmd.BeginSample("BuiltinStack");
@@ -829,6 +830,7 @@ namespace UnityEngine.Rendering.PostProcessing
             if (releaseTargetAfterUse > -1) cmd.ReleaseTemporaryRT(releaseTargetAfterUse);
             if (motionBlurTarget > -1) cmd.ReleaseTemporaryRT(motionBlurTarget);
             if (depthOfFieldTarget > -1) cmd.ReleaseTemporaryRT(motionBlurTarget);
+            if (context.bloomTemporaryRT > -1) cmd.ReleaseTemporaryRT(context.bloomTemporaryRT);
 
             cmd.EndSample("BuiltinStack");
 

--- a/PostProcessing/Runtime/PostProcessRenderContext.cs
+++ b/PostProcessing/Runtime/PostProcessRenderContext.cs
@@ -171,5 +171,6 @@ namespace UnityEngine.Rendering.PostProcessing
         internal LogHistogram logHistogram;
         internal Texture logLut;
         internal AutoExposure autoExposure;
+        internal int bloomTemporaryRT;
     }
 }


### PR DESCRIPTION
I ran into graphical corruption issues with bloom enabled in the stack, and it seemed to be caused by a couple problems fixed by this change:

- The final bloom render target was being released before it was used in the uber shader pass.

- The id for that render target was being assigned to the wrong value (an uninitialized temporary render target) when the bloom pyramid iteration count was 1.