### PR TITLE
Screen-space Reflections improvements

### DIFF
--- a/PostProcessing/Editor/Effects/ScreenSpaceReflectionsEditor.cs
+++ b/PostProcessing/Editor/Effects/ScreenSpaceReflectionsEditor.cs
@@ -12,7 +12,6 @@ namespace UnityEditor.Rendering.PostProcessing
         SerializedParameterOverride m_Resolution;
         SerializedParameterOverride m_MaximumMarchDistance;
         SerializedParameterOverride m_DistanceFade;
-        SerializedParameterOverride m_Attenuation;
         SerializedParameterOverride m_Vignette;
 
         public override void OnEnable()
@@ -23,7 +22,6 @@ namespace UnityEditor.Rendering.PostProcessing
             m_Resolution = FindParameterOverride(x => x.resolution);
             m_MaximumMarchDistance = FindParameterOverride(x => x.maximumMarchDistance);
             m_DistanceFade = FindParameterOverride(x => x.distanceFade);
-            m_Attenuation = FindParameterOverride(x => x.attenuation);
             m_Vignette = FindParameterOverride(x => x.vignette);
         }
 
@@ -54,7 +52,6 @@ namespace UnityEditor.Rendering.PostProcessing
 
             PropertyField(m_MaximumMarchDistance);
             PropertyField(m_DistanceFade);
-            PropertyField(m_Attenuation);
             PropertyField(m_Vignette);
         }
     }

--- a/PostProcessing/Editor/Effects/ScreenSpaceReflectionsEditor.cs
+++ b/PostProcessing/Editor/Effects/ScreenSpaceReflectionsEditor.cs
@@ -13,6 +13,7 @@ namespace UnityEditor.Rendering.PostProcessing
         SerializedParameterOverride m_MaximumMarchDistance;
         SerializedParameterOverride m_DistanceFade;
         SerializedParameterOverride m_Attenuation;
+        SerializedParameterOverride m_Vignette;
 
         public override void OnEnable()
         {
@@ -23,6 +24,7 @@ namespace UnityEditor.Rendering.PostProcessing
             m_MaximumMarchDistance = FindParameterOverride(x => x.maximumMarchDistance);
             m_DistanceFade = FindParameterOverride(x => x.distanceFade);
             m_Attenuation = FindParameterOverride(x => x.attenuation);
+            m_Vignette = FindParameterOverride(x => x.vignette);
         }
 
         public override void OnInspectorGUI()
@@ -53,6 +55,7 @@ namespace UnityEditor.Rendering.PostProcessing
             PropertyField(m_MaximumMarchDistance);
             PropertyField(m_DistanceFade);
             PropertyField(m_Attenuation);
+            PropertyField(m_Vignette);
         }
     }
 }

--- a/PostProcessing/Runtime/Effects/ScreenSpaceReflections.cs
+++ b/PostProcessing/Runtime/Effects/ScreenSpaceReflections.cs
@@ -43,10 +43,7 @@ namespace UnityEngine.Rendering.PostProcessing
         [Range(0f, 1f), Tooltip("Fades reflections close to the near planes.")]
         public FloatParameter distanceFade = new FloatParameter { value = 0.5f };
 
-        [Range(0f, 1f), Tooltip("Fades reflections close to the screen borders.")]
-        public FloatParameter attenuation = new FloatParameter { value = 0.25f };
-
-        [Range(0f, 1f), Tooltip("Fades reflections close to the screen-edges.")]
+        [Range(0f, 1f), Tooltip("Fades reflections close to the screen edges.")]
         public FloatParameter vignette = new FloatParameter { value = 0.5f };
 
         public override bool IsEnabledAndSupported(PostProcessRenderContext context)
@@ -164,9 +161,8 @@ namespace UnityEngine.Rendering.PostProcessing
             sheet.properties.SetMatrix(ShaderIDs.InverseViewMatrix, context.camera.worldToCameraMatrix.inverse);
             sheet.properties.SetMatrix(ShaderIDs.InverseProjectionMatrix, projectionMatrix.inverse);
             sheet.properties.SetMatrix(ShaderIDs.ScreenSpaceProjectionMatrix, screenSpaceProjectionMatrix);
-            sheet.properties.SetVector(ShaderIDs.Params, new Vector4(settings.attenuation.value, settings.distanceFade.value, settings.maximumMarchDistance.value, lodCount));
+            sheet.properties.SetVector(ShaderIDs.Params, new Vector4((float)settings.vignette.value, settings.distanceFade.value, settings.maximumMarchDistance.value, lodCount));
             sheet.properties.SetVector(ShaderIDs.Params2, new Vector4((float)context.width / (float)context.height, (float)size / (float)noiseTex.width, settings.thickness.value, settings.maximumIterationCount.value));
-            sheet.properties.SetVector(ShaderIDs.Params3, new Vector4((float)settings.vignette.value, 0.25f, 0f, 0f));
 
             cmd.GetTemporaryRT(ShaderIDs.Test, size, size, 0, FilterMode.Point, context.sourceFormat);
             cmd.BlitFullscreenTriangle(context.source, ShaderIDs.Test, sheet, (int)Pass.Test);

--- a/PostProcessing/Runtime/Effects/ScreenSpaceReflections.cs
+++ b/PostProcessing/Runtime/Effects/ScreenSpaceReflections.cs
@@ -16,10 +16,10 @@ namespace UnityEngine.Rendering.PostProcessing
     }
 
     [Serializable]
-    public sealed class ScreenSpaceReflectionPresetParameter : ParameterOverride<ScreenSpaceReflectionPreset> {}
+    public sealed class ScreenSpaceReflectionPresetParameter : ParameterOverride<ScreenSpaceReflectionPreset> { }
 
     [Serializable]
-    public sealed class ScreenSpaceReflectionResolutionParameter : ParameterOverride<ScreenSpaceReflectionResolution> {}
+    public sealed class ScreenSpaceReflectionResolutionParameter : ParameterOverride<ScreenSpaceReflectionResolution> { }
 
     [Serializable]
     [PostProcess(typeof(ScreenSpaceReflectionsRenderer), "Unity/Screen-space reflections")]
@@ -45,6 +45,9 @@ namespace UnityEngine.Rendering.PostProcessing
 
         [Range(0f, 1f), Tooltip("Fades reflections close to the screen borders.")]
         public FloatParameter attenuation = new FloatParameter { value = 0.25f };
+
+        [Range(0f, 1f), Tooltip("Fades reflections close to the screen-edges.")]
+        public FloatParameter vignette = new FloatParameter { value = 0.5f };
 
         public override bool IsEnabledAndSupported(PostProcessRenderContext context)
         {
@@ -163,6 +166,7 @@ namespace UnityEngine.Rendering.PostProcessing
             sheet.properties.SetMatrix(ShaderIDs.ScreenSpaceProjectionMatrix, screenSpaceProjectionMatrix);
             sheet.properties.SetVector(ShaderIDs.Params, new Vector4(settings.attenuation.value, settings.distanceFade.value, settings.maximumMarchDistance.value, lodCount));
             sheet.properties.SetVector(ShaderIDs.Params2, new Vector4((float)context.width / (float)context.height, (float)size / (float)noiseTex.width, settings.thickness.value, settings.maximumIterationCount.value));
+            sheet.properties.SetVector(ShaderIDs.Params3, new Vector4((float)settings.vignette.value, 0.25f, 0f, 0f));
 
             cmd.GetTemporaryRT(ShaderIDs.Test, size, size, 0, FilterMode.Point, context.sourceFormat);
             cmd.BlitFullscreenTriangle(context.source, ShaderIDs.Test, sheet, (int)Pass.Test);

--- a/PostProcessing/Runtime/Utils/ShaderIDs.cs
+++ b/PostProcessing/Runtime/Utils/ShaderIDs.cs
@@ -49,7 +49,6 @@ namespace UnityEngine.Rendering.PostProcessing
         internal static readonly int InverseProjectionMatrix         = Shader.PropertyToID("_InverseProjectionMatrix");
         internal static readonly int ScreenSpaceProjectionMatrix     = Shader.PropertyToID("_ScreenSpaceProjectionMatrix");
         internal static readonly int Params2                         = Shader.PropertyToID("_Params2");
-        internal static readonly int Params3                         = Shader.PropertyToID("_Params3");
 
         internal static readonly int FogColor                        = Shader.PropertyToID("_FogColor");
         internal static readonly int FogParams                       = Shader.PropertyToID("_FogParams");

--- a/PostProcessing/Runtime/Utils/ShaderIDs.cs
+++ b/PostProcessing/Runtime/Utils/ShaderIDs.cs
@@ -11,7 +11,7 @@ namespace UnityEngine.Rendering.PostProcessing
         internal static readonly int Sharpness                       = Shader.PropertyToID("_Sharpness");
         internal static readonly int FinalBlendParameters            = Shader.PropertyToID("_FinalBlendParameters");
         internal static readonly int HistoryTex                      = Shader.PropertyToID("_HistoryTex");
-        
+
         internal static readonly int SMAA_Flip                       = Shader.PropertyToID("_SMAA_Flip");
         internal static readonly int SMAA_Flop                       = Shader.PropertyToID("_SMAA_Flop");
 
@@ -38,7 +38,7 @@ namespace UnityEngine.Rendering.PostProcessing
         internal static readonly int Combined1                       = Shader.PropertyToID("Combined1");
         internal static readonly int Combined2                       = Shader.PropertyToID("Combined2");
         internal static readonly int Combined3                       = Shader.PropertyToID("Combined3");
-        
+
         internal static readonly int SSRResolveTemp                  = Shader.PropertyToID("_SSRResolveTemp");
         internal static readonly int Noise                           = Shader.PropertyToID("_Noise");
         internal static readonly int Test                            = Shader.PropertyToID("_Test");
@@ -49,7 +49,8 @@ namespace UnityEngine.Rendering.PostProcessing
         internal static readonly int InverseProjectionMatrix         = Shader.PropertyToID("_InverseProjectionMatrix");
         internal static readonly int ScreenSpaceProjectionMatrix     = Shader.PropertyToID("_ScreenSpaceProjectionMatrix");
         internal static readonly int Params2                         = Shader.PropertyToID("_Params2");
-        
+        internal static readonly int Params3                         = Shader.PropertyToID("_Params3");
+
         internal static readonly int FogColor                        = Shader.PropertyToID("_FogColor");
         internal static readonly int FogParams                       = Shader.PropertyToID("_FogParams");
 

--- a/PostProcessing/Shaders/Builtins/ScreenSpaceReflections.hlsl
+++ b/PostProcessing/Shaders/Builtins/ScreenSpaceReflections.hlsl
@@ -9,7 +9,7 @@
 #define SSR_MINIMUM_ATTENUATION 0.275
 #define SSR_ATTENUATION_SCALE (1.0 - SSR_MINIMUM_ATTENUATION)
 
-#define SSR_VIGNETTE_INTENSITY _Params3.x
+#define SSR_VIGNETTE_INTENSITY _VignetteIntensity
 #define SSR_VIGNETTE_SMOOTHNESS 5.
 
 #define SSR_COLOR_NEIGHBORHOOD_SAMPLE_SPREAD 1.0
@@ -73,10 +73,10 @@ float4x4 _InverseViewMatrix;
 float4x4 _InverseProjectionMatrix;
 float4x4 _ScreenSpaceProjectionMatrix;
 
-float4 _Params; // x: attenuation, y: distance fade, z: maximum march distance, w: blur pyramid lod count
+float4 _Params; // x: vignette intensity, y: distance fade, z: maximum march distance, w: blur pyramid lod count
 float4 _Params2; // x: aspect ratio, y: noise tiling, z: thickness, w: maximum iteration count
-float4 _Params3; // x: vignette intensity, y: vignette smoothness
-#define _Attenuation _Params.x
+#define _Attenuation .25
+#define _VignetteIntensity _Params.x
 #define _DistanceFade _Params.y
 #define _MaximumMarchDistance _Params.z
 #define _BlurPyramidLODCount _Params.w

--- a/PostProcessing/Shaders/Builtins/ScreenSpaceReflections.hlsl
+++ b/PostProcessing/Shaders/Builtins/ScreenSpaceReflections.hlsl
@@ -9,8 +9,8 @@
 #define SSR_MINIMUM_ATTENUATION 0.275
 #define SSR_ATTENUATION_SCALE (1.0 - SSR_MINIMUM_ATTENUATION)
 
-#define SSR_VIGNETTE_INTENSITY 0.7
-#define SSR_VIGNETTE_SMOOTHNESS 0.25
+#define SSR_VIGNETTE_INTENSITY _Params3.x
+#define SSR_VIGNETTE_SMOOTHNESS 5.
 
 #define SSR_COLOR_NEIGHBORHOOD_SAMPLE_SPREAD 1.0
 
@@ -75,6 +75,7 @@ float4x4 _ScreenSpaceProjectionMatrix;
 
 float4 _Params; // x: attenuation, y: distance fade, z: maximum march distance, w: blur pyramid lod count
 float4 _Params2; // x: aspect ratio, y: noise tiling, z: thickness, w: maximum iteration count
+float4 _Params3; // x: vignette intensity, y: vignette smoothness
 #define _Attenuation _Params.x
 #define _DistanceFade _Params.y
 #define _MaximumMarchDistance _Params.z

--- a/PostProcessing/Shaders/Builtins/ScreenSpaceReflections.hlsl
+++ b/PostProcessing/Shaders/Builtins/ScreenSpaceReflections.hlsl
@@ -383,7 +383,9 @@ float4 FragComposite(VaryingsDefault i) : SV_Target
     float4 color = _MainTex.Sample(sampler_MainTex, i.texcoordStereo);
     color.rgb = max(0.0, color.rgb - reflectionProbes.rgb);
 
-    float fade = 1.0 - resolve.a * _DistanceFade;
+    resolve.a *= 2. * resolve.a; // 2 and 1.5 are quite important for the correct ratio of 3:2 distribution
+    float fade = 1.0 - saturate(1.5 * resolve.a * smoothstep(0.5, 1.0, 1.5 * resolve.a) * _DistanceFade);
+
     resolve.rgb = lerp(reflectionProbes.rgb, resolve.rgb, confidence * fade);
     color.rgb += resolve.rgb * gbuffer0.a;
 

--- a/PostProcessing/Shaders/Builtins/ScreenSpaceReflections.hlsl
+++ b/PostProcessing/Shaders/Builtins/ScreenSpaceReflections.hlsl
@@ -101,6 +101,7 @@ float Attenuate(float2 uv)
 float Vignette(float2 uv)
 {
     float2 k = abs(uv - 0.5) * SSR_VIGNETTE_INTENSITY;
+    k.x *= _MainTex_TexelSize.y * _MainTex_TexelSize.z;
     return pow(saturate(1.0 - dot(k, k)), SSR_VIGNETTE_SMOOTHNESS);
 }
 


### PR DESCRIPTION
- Made vignette a public property in place of attenuation, which became a hardwired, one-size-fits-all default.
- Made vignette more controllable and aspect ratio neutral.
- Made distance fade easier on the eyes while trying to maintain reflection sharpness at immediate viewpoint vicinity.
