### PR TITLE
Support v1 monitors on MacOS with Metal

### DIFF
--- a/PostProcessing/Editor Resources/Monitors/HistogramRender.shader
+++ b/PostProcessing/Editor Resources/Monitors/HistogramRender.shader
@@ -8,7 +8,7 @@ Shader "Hidden/Post FX/Monitors/Histogram Render"
         CGINCLUDE
 
             #pragma fragmentoption ARB_precision_hint_fastest
-            #pragma target 5.0
+            #pragma target 4.5
             #include "UnityCG.cginc"
 
             StructuredBuffer<uint4> _Histogram;

--- a/PostProcessing/Editor Resources/Monitors/ParadeRender.shader
+++ b/PostProcessing/Editor Resources/Monitors/ParadeRender.shader
@@ -8,7 +8,7 @@ Shader "Hidden/Post FX/Monitors/Parade Render"
         CGINCLUDE
 
             #pragma fragmentoption ARB_precision_hint_fastest
-            #pragma target 5.0
+            #pragma target 4.5
             #include "UnityCG.cginc"
 
             StructuredBuffer<uint4> _Waveform;

--- a/PostProcessing/Editor Resources/Monitors/VectorscopeCompute.compute
+++ b/PostProcessing/Editor Resources/Monitors/VectorscopeCompute.compute
@@ -8,7 +8,12 @@ CBUFFER_START (Params)
     float4 _Res;
 CBUFFER_END
 
-#define GROUP_SIZE 32
+// Limited thread group size on MacOS with Metal (monitors are Editor-only so don't affect ios/Android limits)
+#if defined SHADER_API_METAL
+    #define GROUP_SIZE 16
+#else
+    #define GROUP_SIZE 32
+#endif
 
 float3 RgbToYUV(float3 c)
 {

--- a/PostProcessing/Editor Resources/Monitors/VectorscopeRender.shader
+++ b/PostProcessing/Editor Resources/Monitors/VectorscopeRender.shader
@@ -8,7 +8,7 @@ Shader "Hidden/Post FX/Monitors/Vectorscope Render"
         CGINCLUDE
 
             #pragma fragmentoption ARB_precision_hint_fastest
-            #pragma target 5.0
+            #pragma target 4.5
             #include "UnityCG.cginc"
 
             StructuredBuffer<uint> _Vectorscope;

--- a/PostProcessing/Editor Resources/Monitors/WaveformCompute.compute
+++ b/PostProcessing/Editor Resources/Monitors/WaveformCompute.compute
@@ -9,9 +9,15 @@ CBUFFER_START (Params)
 CBUFFER_END
 
 #define COLUMNS 384
+// Limited thread group size on MacOS with Metal (monitors are Editor-only so don't affect ios/Android limits)
+#if defined SHADER_API_METAL
+    #define GROUP_SIZE COLUMNS / 2
+#else
+    #define GROUP_SIZE COLUMNS
+#endif
 
 #pragma kernel KWaveform
-[numthreads(1,COLUMNS,1)]
+[numthreads(1,GROUP_SIZE,1)]
 void KWaveform(uint2 dispatchThreadId : SV_DispatchThreadID)
 {
     // We want a gamma corrected colors
@@ -35,7 +41,7 @@ void KWaveform(uint2 dispatchThreadId : SV_DispatchThreadID)
 }
 
 #pragma kernel KWaveformClear
-[numthreads(1, COLUMNS, 1)]
+[numthreads(1, GROUP_SIZE, 1)]
 void KWaveformClear(uint2 dispatchThreadId : SV_DispatchThreadID)
 {
     _Waveform[dispatchThreadId.x * COLUMNS + dispatchThreadId.y] = uint4(0u, 0u, 0u, 0u);

--- a/PostProcessing/Editor Resources/Monitors/WaveformRender.shader
+++ b/PostProcessing/Editor Resources/Monitors/WaveformRender.shader
@@ -8,7 +8,7 @@ Shader "Hidden/Post FX/Monitors/Waveform Render"
         CGINCLUDE
 
             #pragma fragmentoption ARB_precision_hint_fastest
-            #pragma target 5.0
+            #pragma target 4.5
             #include "UnityCG.cginc"
 
             StructuredBuffer<uint4> _Waveform;

--- a/PostProcessing/Editor/Monitors/ParadeMonitor.cs
+++ b/PostProcessing/Editor/Monitors/ParadeMonitor.cs
@@ -10,6 +10,7 @@ namespace UnityEditor.PostProcessing
 
         ComputeShader m_ComputeShader;
         ComputeBuffer m_Buffer;
+        int m_ThreadGroupSize;
         Material m_Material;
         RenderTexture m_WaveformTexture;
         Rect m_MonitorAreaRect;
@@ -17,6 +18,10 @@ namespace UnityEditor.PostProcessing
         public ParadeMonitor()
         {
             m_ComputeShader = EditorResources.Load<ComputeShader>("Monitors/WaveformCompute.compute");
+
+            // Limited thread group size on MacOS with Metal (monitors are Editor-only so don't affect ios/Android limits)
+            bool isMacOSMetal = Application.platform == RuntimePlatform.OSXEditor && SystemInfo.graphicsDeviceType == UnityEngine.Rendering.GraphicsDeviceType.Metal;
+            m_ThreadGroupSize = isMacOSMetal ? 192 : 384;
         }
 
         public override void Dispose()
@@ -226,14 +231,14 @@ namespace UnityEditor.PostProcessing
 
             int kernel = cs.FindKernel("KWaveformClear");
             cs.SetBuffer(kernel, "_Waveform", m_Buffer);
-            cs.Dispatch(kernel, source.width, 1, 1);
+            cs.Dispatch(kernel, source.width, Mathf.CeilToInt(source.height / (float)m_ThreadGroupSize), 1);
 
             kernel = cs.FindKernel("KWaveform");
             cs.SetBuffer(kernel, "_Waveform", m_Buffer);
             cs.SetTexture(kernel, "_Source", source);
             cs.SetInt("_IsLinear", GraphicsUtils.isLinearColorSpace ? 1 : 0);
             cs.SetVector("_Channels", channels);
-            cs.Dispatch(kernel, source.width, 1, 1);
+            cs.Dispatch(kernel, source.width, Mathf.CeilToInt(source.height / (float)m_ThreadGroupSize), 1);
 
             if (m_WaveformTexture == null || m_WaveformTexture.width != (source.width * 3) || m_WaveformTexture.height != source.height)
             {

--- a/PostProcessing/Runtime/Utils/GraphicsUtils.cs
+++ b/PostProcessing/Runtime/Utils/GraphicsUtils.cs
@@ -14,7 +14,7 @@ namespace UnityEngine.PostProcessing
 #if UNITY_WEBGL
             get { return false; }
 #else
-            get { return SystemInfo.graphicsShaderLevel >= 50 && SystemInfo.supportsComputeShaders; }
+            get { return SystemInfo.graphicsShaderLevel >= 45 && SystemInfo.supportsComputeShaders; }
 #endif
         }
 


### PR DESCRIPTION
Fix for #180
Issue was closed due to monitors being fixed on Metal in v2, but until v2 is declared stable it's useful to have working monitors in v1.

Summary:
 - Modified monitor compute shaders & controllers to support variable threadgroup size
 - Reduced monitor threadgroup size on Metal to stay under threadgroup size limit
 - Changed monitor target shader level & compatibility check to 4.5 since systems that support compute but not full 5.0 still support the monitors' shaders