### PR TITLE
Add noperspective interpolation modifier for optimization

### DIFF
--- a/PostProcessing/Resources/Shaders/AmbientOcclusion.cginc
+++ b/PostProcessing/Resources/Shaders/AmbientOcclusion.cginc
@@ -151,9 +151,9 @@ half CompareNormal(half3 d1, half3 d2)
 struct VaryingsMultitex
 {
     float4 pos : SV_POSITION;
-    half2 uv : TEXCOORD0;    // Original UV
-    half2 uv01 : TEXCOORD1;  // Alternative UV (supports v-flip case)
-    half2 uvSPR : TEXCOORD2; // Single pass stereo rendering UV
+    NOPERSPECTIVE half2 uv : TEXCOORD0;    // Original UV
+    NOPERSPECTIVE half2 uv01 : TEXCOORD1;  // Alternative UV (supports v-flip case)
+    NOPERSPECTIVE half2 uvSPR : TEXCOORD2; // Single pass stereo rendering UV
 };
 
 VaryingsMultitex VertMultitex(AttributesDefault v)

--- a/PostProcessing/Resources/Shaders/Blit.shader
+++ b/PostProcessing/Resources/Shaders/Blit.shader
@@ -12,7 +12,7 @@ Shader "Hidden/Post FX/Blit"
 
         struct Varyings
         {
-            float2 uv : TEXCOORD0;
+            NOPERSPECTIVE float2 uv : TEXCOORD0;
             float4 vertex : SV_POSITION;
         };
 

--- a/PostProcessing/Resources/Shaders/Bloom.shader
+++ b/PostProcessing/Resources/Shaders/Bloom.shader
@@ -53,8 +53,8 @@ Shader "Hidden/Post FX/Bloom"
         struct VaryingsMultitex
         {
             float4 pos : SV_POSITION;
-            float2 uvMain : TEXCOORD0;
-            float2 uvBase : TEXCOORD1;
+            NOPERSPECTIVE float2 uvMain : TEXCOORD0;
+            NOPERSPECTIVE float2 uvBase : TEXCOORD1;
         };
 
         VaryingsMultitex VertMultitex(AttributesDefault v)

--- a/PostProcessing/Resources/Shaders/BuiltinDebugViews.shader
+++ b/PostProcessing/Resources/Shaders/BuiltinDebugViews.shader
@@ -120,7 +120,7 @@ Shader "Hidden/Post FX/Builtin Debug Views"
         struct VaryingsArrows
         {
             float4 vertex : SV_POSITION;
-            float2 scoord : TEXCOORD;
+            NOPERSPECTIVE float2 scoord : TEXCOORD;
             float4 color : COLOR;
         };
 

--- a/PostProcessing/Resources/Shaders/Common.cginc
+++ b/PostProcessing/Resources/Shaders/Common.cginc
@@ -8,6 +8,16 @@
 
 #define MOBILE_OR_CONSOLE (defined(SHADER_API_MOBILE) || defined(SHADER_API_PSSL) || defined(SHADER_API_XBOXONE) || defined(SHADER_API_WIIU))
 
+#define USE_NOPERSPECTIVE 1
+
+#ifndef NOPERSPECTIVE
+#  if defined(USE_NOPERSPECTIVE) && (USE_NOPERSPECTIVE)
+#    define NOPERSPECTIVE noperspective
+#  else
+#    define NOPERSPECTIVE
+#  endif
+#endif
+
 #if defined(SHADER_API_PSSL)
 // No support for sampler2D_half on PS4 in 5.4
 #define sampler2D_half sampler2D_float
@@ -31,14 +41,14 @@ float4 _MainTex_ST;
 struct AttributesDefault
 {
     float4 vertex : POSITION;
-    float4 texcoord : TEXCOORD0;
+    NOPERSPECTIVE float4 texcoord : TEXCOORD0;
 };
 
 struct VaryingsDefault
 {
     float4 pos : SV_POSITION;
-    float2 uv : TEXCOORD0;
-    float2 uvSPR : TEXCOORD1; // Single Pass Stereo UVs
+    NOPERSPECTIVE float2 uv : TEXCOORD0;
+    NOPERSPECTIVE float2 uvSPR : TEXCOORD1; // Single Pass Stereo UVs
 };
 
 VaryingsDefault VertDefault(AttributesDefault v)

--- a/PostProcessing/Resources/Shaders/DepthOfField.cginc
+++ b/PostProcessing/Resources/Shaders/DepthOfField.cginc
@@ -29,8 +29,8 @@ half3 _TaaParams; // Jitter.x, Jitter.y, Blending
 struct VaryingsDOF
 {
     float4 pos : SV_POSITION;
-    half2 uv : TEXCOORD0;
-    half2 uvAlt : TEXCOORD1;
+    NOPERSPECTIVE half2 uv : TEXCOORD0;
+    NOPERSPECTIVE half2 uvAlt : TEXCOORD1;
 };
 
 // Common vertex shader with single pass stereo rendering support

--- a/PostProcessing/Resources/Shaders/EyeAdaptation.shader
+++ b/PostProcessing/Resources/Shaders/EyeAdaptation.shader
@@ -131,7 +131,7 @@ Shader "Hidden/Post FX/Eye Adaptation"
         struct VaryingsEditorHisto
         {
             float4 pos : SV_POSITION;
-            float2 uv : TEXCOORD0;
+            NOPERSPECTIVE float2 uv : TEXCOORD0;
             float maxValue : TEXCOORD1;
             float avgLuminance : TEXCOORD2;
         };

--- a/PostProcessing/Resources/Shaders/Fog.shader
+++ b/PostProcessing/Resources/Shaders/Fog.shader
@@ -15,7 +15,7 @@ Shader "Hidden/Post FX/Fog"
 
         struct Varyings
         {
-            float2 uv : TEXCOORD0;
+            NOPERSPECTIVE float2 uv : TEXCOORD0;
             float4 vertex : SV_POSITION;
         };
 

--- a/PostProcessing/Resources/Shaders/MotionBlur.cginc
+++ b/PostProcessing/Resources/Shaders/MotionBlur.cginc
@@ -52,8 +52,8 @@ half _History4Weight;
 struct VaryingsMultitex
 {
     float4 pos : SV_POSITION;
-    float2 uv0 : TEXCOORD0;
-    float2 uv1 : TEXCOORD1;
+    NOPERSPECTIVE float2 uv0 : TEXCOORD0;
+    NOPERSPECTIVE float2 uv1 : TEXCOORD1;
 };
 
 VaryingsMultitex VertMultitex(AttributesDefault v)

--- a/PostProcessing/Resources/Shaders/ScreenSpaceReflection.shader
+++ b/PostProcessing/Resources/Shaders/ScreenSpaceReflection.shader
@@ -89,8 +89,8 @@ Shader "Hidden/Post FX/Screen Space Reflection"
         struct v2f
         {
             float4 pos : SV_POSITION;
-            float2 uv : TEXCOORD0;
-            float2 uv2 : TEXCOORD1;
+            NOPERSPECTIVE float2 uv : TEXCOORD0;
+            NOPERSPECTIVE float2 uv2 : TEXCOORD1;
         };
 
         v2f vert( appdata_img v )

--- a/PostProcessing/Resources/Shaders/TAA.cginc
+++ b/PostProcessing/Resources/Shaders/TAA.cginc
@@ -25,7 +25,7 @@
 struct VaryingsSolver
 {
     float4 vertex : SV_POSITION;
-    float4 uv : TEXCOORD0; // [xy: _MainTex.uv, zw: _HistoryTex.uv]
+    NOPERSPECTIVE float4 uv : TEXCOORD0; // [xy: _MainTex.uv, zw: _HistoryTex.uv]
 };
 
 struct OutputSolver

--- a/PostProcessing/Resources/Shaders/Uber.shader
+++ b/PostProcessing/Resources/Shaders/Uber.shader
@@ -74,10 +74,10 @@ Shader "Hidden/Post FX/Uber Shader"
         struct VaryingsFlipped
         {
             float4 pos : SV_POSITION;
-            float2 uv : TEXCOORD0;
-            float2 uvSPR : TEXCOORD1; // Single Pass Stereo UVs
-            float2 uvFlipped : TEXCOORD2; // Flipped UVs (DX/MSAA/Forward)
-            float2 uvFlippedSPR : TEXCOORD3; // Single Pass Stereo flipped UVs
+            NOPERSPECTIVE float2 uv : TEXCOORD0;
+            NOPERSPECTIVE float2 uvSPR : TEXCOORD1; // Single Pass Stereo UVs
+            NOPERSPECTIVE float2 uvFlipped : TEXCOORD2; // Flipped UVs (DX/MSAA/Forward)
+            NOPERSPECTIVE float2 uvFlippedSPR : TEXCOORD3; // Single Pass Stereo flipped UVs
         };
 
         VaryingsFlipped VertUber(AttributesDefault v)


### PR DESCRIPTION
This PR improves shader performance by `noperspective` interpolation modifier.

I've added the following macros to `PostProcessing/Resources/Shaders/Common.cginc`
- `USE_NOPERSPECTIVE` : compilation switch for `noperspective`.  If someone or some platform doesn't need `noperspective`, they can comment out this line.
- `NOPERSPECTIVE` : macro definition of `noperspective` for `TEXCOORD` attributes.

```
#define USE_NOPERSPECTIVE 1

#ifndef NOPERSPECTIVE
#  if defined(USE_NOPERSPECTIVE) && (USE_NOPERSPECTIVE)
#    define NOPERSPECTIVE noperspective
#  else
#    define NOPERSPECTIVE
#  endif
#endif
```
