### PR TITLE
Add LayerMaskComparer to avoid garbage allocations

### DIFF
--- a/PostProcessing/Runtime/PostProcessManager.cs
+++ b/PostProcessing/Runtime/PostProcessManager.cs
@@ -410,8 +410,14 @@ namespace UnityEngine.Rendering.PostProcessing
         
         public class LayerMaskComparer : IEqualityComparer<LayerMask>
         {
-            public bool Equals(LayerMask x, LayerMask y) => x.value == y.value;
-            public int GetHashCode(LayerMask obj) => obj.value;
+            public bool Equals(LayerMask x, LayerMask y)
+            {
+                return x.value == y.value;
+            }
+            public int GetHashCode(LayerMask obj)
+            {
+                return obj.value;
+            }
         }
     }
 }

--- a/PostProcessing/Runtime/PostProcessManager.cs
+++ b/PostProcessing/Runtime/PostProcessManager.cs
@@ -33,9 +33,9 @@ namespace UnityEngine.Rendering.PostProcessing
 
         PostProcessManager()
         {
-            m_SortedVolumes = new Dictionary<int, List<PostProcessVolume>>();
+            m_SortedVolumes = new Dictionary<int, List<PostProcessVolume>>(new LayerMaskComparer());
             m_Volumes = new List<PostProcessVolume>();
-            m_SortNeeded = new Dictionary<int, bool>();
+            m_SortNeeded = new Dictionary<int, bool>(new LayerMaskComparer());
             m_BaseSettings = new List<PostProcessEffectSettings>();
             m_TempColliders = new List<Collider>(5);
 
@@ -406,6 +406,12 @@ namespace UnityEngine.Rendering.PostProcessing
 
                 volumes[j + 1] = temp;
             }
+        }
+        
+        public class LayerMaskComparer : IEqualityComparer<LayerMask>
+        {
+            public bool Equals(LayerMask x, LayerMask y) => x.value == y.value;
+            public int GetHashCode(LayerMask obj) => obj.value;
         }
     }
 }


### PR DESCRIPTION
The `LayerMask` struct doesn't implement the `IEquatable<T>` interface which causes unnecessary garbage allocation during comparisons. We can avoid that by providing an `IEqualityComparer<LayerMask>` instance to the dictionary constructor.