### PR TITLE
Fix a temporary RT for DoF not being released when requested.

### DIFF
--- a/PostProcessing/Runtime/PostProcessLayer.cs
+++ b/PostProcessing/Runtime/PostProcessLayer.cs
@@ -848,7 +848,7 @@ namespace UnityEngine.Rendering.PostProcessing
 
             if (releaseTargetAfterUse > -1) cmd.ReleaseTemporaryRT(releaseTargetAfterUse);
             if (motionBlurTarget > -1) cmd.ReleaseTemporaryRT(motionBlurTarget);
-            if (depthOfFieldTarget > -1) cmd.ReleaseTemporaryRT(motionBlurTarget);
+            if (depthOfFieldTarget > -1) cmd.ReleaseTemporaryRT(depthOfFieldTarget);
             if (context.bloomBufferNameID > -1) cmd.ReleaseTemporaryRT(context.bloomBufferNameID);
 
             cmd.EndSample("BuiltinStack");


### PR DESCRIPTION
The CommandBuffer API still releases it at the end of the frame without this fix, but the fix allows more reuse within the frame.