### PR TITLE
OpenGL ES 3: Disable ColorGrading 3D lut code path

### DIFF
--- a/PostProcessing/Runtime/Effects/ColorGrading.cs
+++ b/PostProcessing/Runtime/Effects/ColorGrading.cs
@@ -176,7 +176,8 @@ namespace UnityEngine.Rendering.PostProcessing
             var gradingMode = settings.gradingMode.value;
             var supportComputeTex3D = SystemInfo.supports3DRenderTextures
                 && SystemInfo.supportsComputeShaders
-                && SystemInfo.graphicsDeviceType != GraphicsDeviceType.OpenGLCore;
+                && SystemInfo.graphicsDeviceType != GraphicsDeviceType.OpenGLCore
+                && SystemInfo.graphicsDeviceType != GraphicsDeviceType.OpenGLES3;
 
             if (gradingMode == GradingMode.External)
                 RenderExternalPipeline3D(context);


### PR DESCRIPTION
There are various issues reported for this path, so disable it for now.
