### PR TITLE
Workaround to disable compute shaders for OpenGL ES 3 in Unity 2017.x

### DIFF
--- a/PostProcessing/Shaders/API/OpenGL.hlsl
+++ b/PostProcessing/Shaders/API/OpenGL.hlsl
@@ -48,3 +48,9 @@
 
 #define FXAA_HLSL_3 1
 #define SMAA_HLSL_3 1
+
+// pragma exclude_renderers is only supported since Unity 2018.1 for compute shaders
+#if UNITY_VERSION < 201810 && !defined(SHADER_API_GLCORE)
+#    define DISABLE_COMPUTE_SHADERS 1
+#    define TRIVIAL_COMPUTE_KERNEL(name) [numthreads(1, 1, 1)] void name() {}
+#endif

--- a/PostProcessing/Shaders/Builtins/AutoExposure.compute
+++ b/PostProcessing/Shaders/Builtins/AutoExposure.compute
@@ -36,6 +36,12 @@ float InterpolateExposure(float newExposure, float oldExposure)
     return exposure;
 }
 
+#ifdef DISABLE_COMPUTE_SHADERS
+
+TRIVIAL_COMPUTE_KERNEL(MAIN)
+
+#else
+
 [numthreads(HISTOGRAM_THREAD_X, HISTOGRAM_BINS / HISTOGRAM_THREAD_X, 1)]
 void MAIN(uint2 groupThreadId : SV_GroupThreadID)
 {
@@ -83,3 +89,5 @@ void MAIN(uint2 groupThreadId : SV_GroupThreadID)
 #endif
     }
 }
+
+#endif // DISABLE_COMPUTE_SHADERS

--- a/PostProcessing/Shaders/Builtins/ExposureHistogram.compute
+++ b/PostProcessing/Shaders/Builtins/ExposureHistogram.compute
@@ -19,6 +19,14 @@ CBUFFER_END
 groupshared uint gs_histogram[HISTOGRAM_BINS];
 
 #pragma kernel KEyeHistogram
+
+#ifdef DISABLE_COMPUTE_SHADERS
+
+TRIVIAL_COMPUTE_KERNEL(KEyeHistogram)
+TRIVIAL_COMPUTE_KERNEL(KEyeHistogramClear)
+
+#else
+
 [numthreads(HISTOGRAM_THREAD_X, HISTOGRAM_THREAD_Y, 1)]
 void KEyeHistogram(uint2 dispatchThreadId : SV_DispatchThreadID, uint2 groupThreadId : SV_GroupThreadID)
 {
@@ -74,3 +82,5 @@ void KEyeHistogramClear(uint dispatchThreadId : SV_DispatchThreadID)
     if (dispatchThreadId < HISTOGRAM_BINS)
         _HistogramBuffer[dispatchThreadId] = 0u;
 }
+
+#endif // DISABLE_COMPUTE_SHADERS

--- a/PostProcessing/Shaders/Builtins/GaussianDownsample.compute
+++ b/PostProcessing/Shaders/Builtins/GaussianDownsample.compute
@@ -116,6 +116,13 @@ void BlurVertically(uint2 pixelCoord, uint topMostIndex)
 }
 
 #pragma kernel KMain
+
+#ifdef DISABLE_COMPUTE_SHADERS
+
+TRIVIAL_COMPUTE_KERNEL(KMain)
+
+#else
+
 [numthreads(8, 8, 1)]
 void KMain(uint2 groupId : SV_GroupID, uint2 groupThreadId : SV_GroupThreadID, uint2 dispatchThreadId : SV_DispatchThreadID)
 {
@@ -145,3 +152,5 @@ void KMain(uint2 groupId : SV_GroupID, uint2 groupThreadId : SV_GroupThreadID, u
     // Vertically blur the pixels in LDS and write the result to memory
     BlurVertically(dispatchThreadId, (groupThreadId.y << 3u) + groupThreadId.x);
 }
+
+#endif // DISABLE_COMPUTE_SHADERS

--- a/PostProcessing/Shaders/Builtins/Lut3DBaker.compute
+++ b/PostProcessing/Shaders/Builtins/Lut3DBaker.compute
@@ -159,6 +159,16 @@ void Eval(uint3 id)
     #define GROUP_SIZE_Z 8
 #endif
 
+
+#ifdef DISABLE_COMPUTE_SHADERS
+
+TRIVIAL_COMPUTE_KERNEL(KGenLut3D_NoTonemap)
+TRIVIAL_COMPUTE_KERNEL(KGenLut3D_AcesTonemap)
+TRIVIAL_COMPUTE_KERNEL(KGenLut3D_NeutralTonemap)
+TRIVIAL_COMPUTE_KERNEL(KGenLut3D_CustomTonemap)
+
+#else
+
 [numthreads(GROUP_SIZE_XY, GROUP_SIZE_XY, GROUP_SIZE_Z)]
 void KGenLut3D_NoTonemap(uint3 id : SV_DispatchThreadID) { Eval(id); }
 
@@ -170,3 +180,5 @@ void KGenLut3D_NeutralTonemap(uint3 id : SV_DispatchThreadID) { Eval(id); }
 
 [numthreads(GROUP_SIZE_XY, GROUP_SIZE_XY, GROUP_SIZE_Z)]
 void KGenLut3D_CustomTonemap(uint3 id : SV_DispatchThreadID) { Eval(id); }
+
+#endif // DISABLE_COMPUTE_SHADERS

--- a/PostProcessing/Shaders/Builtins/MultiScaleVODownsample1.compute
+++ b/PostProcessing/Shaders/Builtins/MultiScaleVODownsample1.compute
@@ -53,6 +53,12 @@ float Linearize(uint2 st)
 
 groupshared float g_CacheW[256];
 
+#ifdef DISABLE_COMPUTE_SHADERS
+
+TRIVIAL_COMPUTE_KERNEL(main)
+
+#else
+
 [numthreads(8, 8, 1)]
 void main(uint3 Gid : SV_GroupID, uint GI : SV_GroupIndex, uint3 GTid : SV_GroupThreadID, uint3 DTid : SV_DispatchThreadID)
 {
@@ -83,3 +89,5 @@ void main(uint3 Gid : SV_GroupID, uint GI : SV_GroupIndex, uint3 GTid : SV_Group
     }
 
 }
+
+#endif

--- a/PostProcessing/Shaders/Builtins/MultiScaleVODownsample2.compute
+++ b/PostProcessing/Shaders/Builtins/MultiScaleVODownsample2.compute
@@ -24,6 +24,8 @@
 
 #pragma kernel main
 
+#include "../StdLib.hlsl"
+
 Texture2D<float> DS4x;
 RWTexture2D<float> DS8x;
 RWTexture2DArray<float> DS8xAtlas;

--- a/PostProcessing/Shaders/Builtins/MultiScaleVODownsample2.compute
+++ b/PostProcessing/Shaders/Builtins/MultiScaleVODownsample2.compute
@@ -30,6 +30,12 @@ RWTexture2DArray<float> DS8xAtlas;
 RWTexture2D<float> DS16x;
 RWTexture2DArray<float> DS16xAtlas;
 
+#ifdef DISABLE_COMPUTE_SHADERS
+
+TRIVIAL_COMPUTE_KERNEL(main)
+
+#else
+
 [numthreads(8, 8, 1)]
 void main(uint3 Gid : SV_GroupID, uint GI : SV_GroupIndex, uint3 GTid : SV_GroupThreadID, uint3 DTid : SV_DispatchThreadID)
 {
@@ -50,3 +56,5 @@ void main(uint3 Gid : SV_GroupID, uint GI : SV_GroupIndex, uint3 GTid : SV_Group
         DS16xAtlas[uint3(stAtlas, stSlice)] = m1;
     }
 }
+
+#endif // DISABLE_COMPUTE_SHADERS

--- a/PostProcessing/Shaders/Builtins/MultiScaleVORender.compute
+++ b/PostProcessing/Shaders/Builtins/MultiScaleVORender.compute
@@ -118,6 +118,12 @@ float TestSamples(uint centerIdx, uint x, uint y, float invDepth, float invThick
     }
 }
 
+#ifdef DISABLE_COMPUTE_SHADERS
+
+TRIVIAL_COMPUTE_KERNEL(MAIN)
+
+#else
+
 [numthreads(THREAD_COUNT_X, THREAD_COUNT_Y, 1)]
 void MAIN(uint3 Gid : SV_GroupID, uint GI : SV_GroupIndex, uint3 GTid : SV_GroupThreadID, uint3 DTid : SV_DispatchThreadID)
 {
@@ -184,3 +190,5 @@ void MAIN(uint3 Gid : SV_GroupID, uint GI : SV_GroupIndex, uint3 GTid : SV_Group
 #endif
     Occlusion[OutPixel] = lerp(1, ao, gIntensity);
 }
+
+#endif // DISABLE_COMPUTE_SHADERS

--- a/PostProcessing/Shaders/Builtins/MultiScaleVOUpsample.compute
+++ b/PostProcessing/Shaders/Builtins/MultiScaleVOUpsample.compute
@@ -188,6 +188,12 @@ float BilateralUpsample(float HiDepth, float HiAO, float4 LowDepths, float4 LowA
     return HiAO * WeightedSum / TotalWeight;
 }
 
+#ifdef DISABLE_COMPUTE_SHADERS
+
+TRIVIAL_COMPUTE_KERNEL(MAIN)
+
+#else
+
 [numthreads(8, 8, 1)]
 void MAIN(uint3 Gid : SV_GroupID, uint GI : SV_GroupIndex, uint3 GTid : SV_GroupThreadID, uint3 DTid : SV_DispatchThreadID)
 {
@@ -245,3 +251,5 @@ void MAIN(uint3 Gid : SV_GroupID, uint GI : SV_GroupIndex, uint3 GTid : SV_Group
     AoResult[OutST + int2(-1, -1)] = BilateralUpsample(HiDepths.w, HiSSAOs.w, LoDepths.wxyz, LoSSAOs.wxyz);
 #endif
 }
+
+#endif // DISABLE_COMPUTE_SHADERS

--- a/PostProcessing/Shaders/Builtins/Texture3DLerp.compute
+++ b/PostProcessing/Shaders/Builtins/Texture3DLerp.compute
@@ -16,6 +16,12 @@ Texture3D _To;
 
 #define GROUP_SIZE 8
 
+#ifdef DISABLE_COMPUTE_SHADERS
+
+TRIVIAL_COMPUTE_KERNEL(KTexture3DLerp)
+
+#else
+
 [numthreads(GROUP_SIZE, GROUP_SIZE, GROUP_SIZE)]
 void KTexture3DLerp(uint3 id : SV_DispatchThreadID)
 {
@@ -26,3 +32,5 @@ void KTexture3DLerp(uint3 id : SV_DispatchThreadID)
         _Output[id] = float4(lerp(from, to, _Params.xxx), 1.0);
     }
 }
+
+#endif // DISABLE_COMPUTE_SHADERS


### PR DESCRIPTION
`#pragma exclude_renderers` for compute is only supported since Unity 2018.1.
This generates "empty" shaders in older Unity versions (for OpenGL ES 3.1+ only).