### PR TITLE
FogEffect

### DIFF
--- a/PostProcessing/Editor/Effects/FogEditor.cs
+++ b/PostProcessing/Editor/Effects/FogEditor.cs
@@ -1,0 +1,44 @@
+﻿using UnityEngine;
+using UnityEngine.Rendering.PostProcessing;
+
+namespace UnityEditor.Rendering.PostProcessing
+{
+    [PostProcessEditor(typeof(Fog))]
+    public sealed class FogEditor : PostProcessEffectEditor<Fog>
+    {
+        SerializedParameterOverride m_excludeSkybox;
+        SerializedParameterOverride m_color;
+        SerializedParameterOverride m_density;
+        SerializedParameterOverride m_startDistance;
+        SerializedParameterOverride m_endDistance;
+        SerializedParameterOverride m_mode;
+
+        public override void OnEnable()
+        {
+            m_excludeSkybox = FindParameterOverride(x => x.excludeSkybox);
+            m_color = FindParameterOverride(x => x.color);
+            m_density = FindParameterOverride(x => x.density);
+            m_startDistance = FindParameterOverride(x => x.startDistance);
+            m_endDistance = FindParameterOverride(x => x.endDistance);
+            m_mode = FindParameterOverride(x => x.mode);
+        }
+
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+
+            PropertyField(m_excludeSkybox);
+            PropertyField(m_color);
+            PropertyField(m_mode);
+            if (m_mode.value.intValue == (int)FogMode.Linear)
+            {
+                PropertyField(m_startDistance);
+                PropertyField(m_endDistance);
+            }
+            else if (m_mode.value.intValue == (int)FogMode.Exponential || m_mode.value.intValue == (int)FogMode.ExponentialSquared)
+            {
+                PropertyField(m_density);
+            }
+        }
+    }
+}

--- a/PostProcessing/Editor/Effects/FogEditor.cs.meta
+++ b/PostProcessing/Editor/Effects/FogEditor.cs.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 46055dc47f498a24489f722f15b79138
-timeCreated: 1522675740
+guid: 356a7c80dc030f24a91cb96353cc88a2
+timeCreated: 1522677212
 licenseType: Free
 MonoImporter:
   externalObjects: {}

--- a/PostProcessing/Runtime/Effects/DeferredFog.cs
+++ b/PostProcessing/Runtime/Effects/DeferredFog.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace UnityEngine.Rendering.PostProcessing
+{
+    [Serializable]
+    public sealed class DeferredFog
+    {
+        [Tooltip("Enables the internal deferred fog pass. Actual fog settings should be set in the Lighting panel.")]
+        public bool enabled = true;
+
+        [Tooltip("Should the fog affect the skybox?")]
+        public bool excludeSkybox = true;
+
+        internal DepthTextureMode GetCameraFlags()
+        {
+            return DepthTextureMode.Depth;
+        }
+
+        internal bool IsEnabledAndSupported(PostProcessRenderContext context)
+        {
+            return enabled
+                && RenderSettings.fog
+                && !RuntimeUtilities.scriptableRenderPipelineActive
+                && context.resources.shaders.deferredFog
+                && context.resources.shaders.deferredFog.isSupported
+                && context.camera.actualRenderingPath == RenderingPath.DeferredShading;  // In forward fog is already done at shader level
+        }
+
+        internal void Render(PostProcessRenderContext context)
+        {
+            var sheet = context.propertySheets.Get(context.resources.shaders.deferredFog);
+            sheet.ClearKeywords();
+
+            var fogColor = RuntimeUtilities.isLinearColorSpace ? RenderSettings.fogColor.linear : RenderSettings.fogColor;
+            sheet.properties.SetVector(ShaderIDs.FogColor, fogColor);
+            sheet.properties.SetVector(ShaderIDs.FogParams, new Vector3(RenderSettings.fogDensity, RenderSettings.fogStartDistance, RenderSettings.fogEndDistance));
+
+            var cmd = context.command;
+            cmd.BlitFullscreenTriangle(context.source, context.destination, sheet, excludeSkybox ? 1 : 0);
+        }
+    }
+}

--- a/PostProcessing/Runtime/Effects/DeferredFog.cs.meta
+++ b/PostProcessing/Runtime/Effects/DeferredFog.cs.meta
@@ -1,9 +1,8 @@
 fileFormatVersion: 2
-guid: 46055dc47f498a24489f722f15b79138
-timeCreated: 1522675740
-licenseType: Free
+guid: 62e2b920ea5fcaa4982e7fc50bf690a8
+timeCreated: 1498381577
+licenseType: Pro
 MonoImporter:
-  externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0

--- a/PostProcessing/Runtime/Effects/Fog.cs
+++ b/PostProcessing/Runtime/Effects/Fog.cs
@@ -3,40 +3,88 @@ using System;
 namespace UnityEngine.Rendering.PostProcessing
 {
     [Serializable]
-    public sealed class Fog
+    [PostProcess(typeof(FogRenderer), PostProcessEvent.AfterStack, "Unity/Fog")]
+    public sealed class Fog : PostProcessEffectSettings
     {
-        [Tooltip("Enables the internal deferred fog pass. Actual fog settings should be set in the Lighting panel.")]
-        public bool enabled = true;
+        [Serializable]
+        public sealed class FogModeParameter : ParameterOverride<FogMode> { }
 
-        [Tooltip("Should the fog affect the skybox?")]
-        public bool excludeSkybox = true;
+        public BoolParameter excludeSkybox = new BoolParameter { value = false };
+        public ColorParameter color = new ColorParameter { value = Color.gray };
+        public FloatParameter density = new FloatParameter { value = 0.01f };
+        public FloatParameter startDistance = new FloatParameter { value = 100 };
+        public FloatParameter endDistance = new FloatParameter { value = 200 };
+        public FogModeParameter mode = new FogModeParameter { value = FogMode.Exponential };
 
-        internal DepthTextureMode GetCameraFlags()
+        public override bool IsEnabledAndSupported(PostProcessRenderContext context)
         {
-            return DepthTextureMode.Depth;
+            // Never rendered directly
+            return false;
         }
 
-        internal bool IsEnabledAndSupported(PostProcessRenderContext context)
+        public override void Reset(PostProcessEffectSettings defaultSettings)
         {
-            return enabled
-                && RenderSettings.fog
-                && !RuntimeUtilities.scriptableRenderPipelineActive
-                && context.resources.shaders.deferredFog
-                && context.resources.shaders.deferredFog.isSupported
-                && context.camera.actualRenderingPath == RenderingPath.DeferredShading;  // In forward fog is already done at shader level
+            base.Reset(defaultSettings);
+
+            enabled.value = RenderSettings.fog;
+            color.value = RenderSettings.fogColor;
+            density.value = RenderSettings.fogDensity;
+            startDistance.value = RenderSettings.fogStartDistance;
+            endDistance.value = RenderSettings.fogEndDistance;
+            mode.value = RenderSettings.fogMode;
+        }
+    }
+
+    public sealed class FogRenderer : PostProcessEffectRenderer<Fog>
+    {
+        Fog m_backupSettings = ScriptableObject.CreateInstance<Fog>();
+
+        public override void Render(PostProcessRenderContext context)
+        {
+            throw new NotSupportedException();
         }
 
-        internal void Render(PostProcessRenderContext context)
+        static void Load(Fog settings, ref bool excludeSkybox)
         {
-            var sheet = context.propertySheets.Get(context.resources.shaders.deferredFog);
-            sheet.ClearKeywords();
+            excludeSkybox = settings.excludeSkybox;
+            RenderSettings.fog = settings.enabled;
+            RenderSettings.fogColor = settings.color;
+            RenderSettings.fogDensity = settings.density;
+            RenderSettings.fogStartDistance = settings.startDistance;
+            RenderSettings.fogEndDistance = settings.endDistance;
+            RenderSettings.fogMode = settings.mode;
+        }
 
-            var fogColor = RuntimeUtilities.isLinearColorSpace ? RenderSettings.fogColor.linear : RenderSettings.fogColor;
-            sheet.properties.SetVector(ShaderIDs.FogColor, fogColor);
-            sheet.properties.SetVector(ShaderIDs.FogParams, new Vector3(RenderSettings.fogDensity, RenderSettings.fogStartDistance, RenderSettings.fogEndDistance));
+        static void Store(Fog result, bool excludeSkybox)
+        {
+            result.excludeSkybox.value = excludeSkybox;
+            result.enabled.value = RenderSettings.fog;
+            result.color.value = RenderSettings.fogColor;
+            result.density.value = RenderSettings.fogDensity;
+            result.startDistance.value = RenderSettings.fogStartDistance;
+            result.endDistance.value = RenderSettings.fogEndDistance;
+            result.mode.value = RenderSettings.fogMode;
+        }
 
-            var cmd = context.command;
-            cmd.BlitFullscreenTriangle(context.source, context.destination, sheet, excludeSkybox ? 1 : 0);
+        public void ApplySettings(PostProcessRenderContext context, ref bool excludeSkybox)
+        {
+            // Backup settings
+            Store(m_backupSettings, excludeSkybox);
+
+            // Apply settings
+            Load(settings, ref excludeSkybox);
+
+#if UNITY_EDITOR
+            if (context.isSceneView && !UnityEditor.SceneView.currentDrawingSceneView.sceneViewState.showFog)
+            {
+                RenderSettings.fog = false;
+            }
+#endif
+        }
+
+        public void RestoreSettings(ref bool excludeSkybox)
+        {
+            Load(m_backupSettings, ref excludeSkybox);
         }
     }
 }

--- a/PostProcessing/Runtime/PostProcessEffectSettings.cs
+++ b/PostProcessing/Runtime/PostProcessEffectSettings.cs
@@ -75,5 +75,13 @@ namespace UnityEngine.Rendering.PostProcessing
                 return hash;
             }
         }
+
+        public virtual void Reset(PostProcessEffectSettings defaultSettings)
+        {
+            int count = defaultSettings.parameters.Count;
+
+            for (int i = 0; i < count; i++)
+                parameters[i].SetValue(defaultSettings.parameters[i]);
+        }
     }
 }

--- a/PostProcessing/Runtime/PostProcessLayer.cs
+++ b/PostProcessing/Runtime/PostProcessLayer.cs
@@ -35,7 +35,7 @@ namespace UnityEngine.Rendering.PostProcessing
         public TemporalAntialiasing temporalAntialiasing;
         public SubpixelMorphologicalAntialiasing subpixelMorphologicalAntialiasing;
         public FastApproximateAntialiasing fastApproximateAntialiasing;
-        public Fog fog;
+        public DeferredFog fog;
         public Dithering dithering;
 
         public PostProcessDebugLayer debugLayer;
@@ -327,6 +327,13 @@ namespace UnityEngine.Rendering.PostProcessing
             TextureLerper.instance.BeginFrame(context);
             UpdateSettingsIfNeeded(context);
 
+            // Fog effect settings
+            var fogBundle = GetBundle<Fog>();
+            if (fogBundle != null)
+            {
+                fogBundle.CastRenderer<FogRenderer>().ApplySettings(context, ref fog.excludeSkybox);
+            }
+
             // Lighting & opaque-only effects
             var aoBundle = GetBundle<AmbientOcclusion>();
             var aoSettings = aoBundle.CastSettings<AmbientOcclusion>();
@@ -441,6 +448,13 @@ namespace UnityEngine.Rendering.PostProcessing
             // Unused in scriptable render pipelines
             if (RuntimeUtilities.scriptableRenderPipelineActive)
                 return;
+
+            // Restore original fog settings
+            var fogBundle = GetBundle<Fog>();
+            if (fogBundle != null)
+            {
+                fogBundle.CastRenderer<FogRenderer>().RestoreSettings(ref fog.excludeSkybox);
+            }
 
             if (m_CurrentContext.IsTemporalAntialiasingActive())
             {

--- a/PostProcessing/Runtime/PostProcessManager.cs
+++ b/PostProcessing/Runtime/PostProcessManager.cs
@@ -271,10 +271,7 @@ namespace UnityEngine.Rendering.PostProcessing
             foreach (var settings in m_BaseSettings)
             {
                 var target = postProcessLayer.GetBundle(settings.GetType()).settings;
-                int count = settings.parameters.Count;
-
-                for (int i = 0; i < count; i++)
-                    target.parameters[i].SetValue(settings.parameters[i]);
+                target.Reset(settings);
             }
         }
 


### PR DESCRIPTION
Renamed original Fog to DeferredFog (because it is only deferred effect)
Added Fog effect which modifies RenderSettings before rendering and restores after rendering

Related to #512 

**Implementation consists of three parts**

1. Loading base fog values from RenderSettings in PostProcessEffectSettings.Reset.
2. Applying fog to RenderSettings in OnPreCull
3. Restoring original RenderSettings fog values in OnPostRender

Loading base values is necessary for overrides to work properly. We want overrides to work 'on top' of settings which are in RenderSettings.

**What works**
- Fog settings
- Overrides
- Consistent fog on transparent and opaque materials
- Different fog on multiple cameras
- Fog blending between volumes
- Preview in scene view (image effects/fog)

**Possible issues**
- Baking lights?
- GI (Enlighten)?

Not sure how light baking and Enlighten GI works, it might use fog from global RenderSettings for some calculations.