### PR TITLE
Remove #pragma multi_compile __ UNITY_COLORSPACE_GAMMA

### DIFF
--- a/PostProcessing/Shaders/Builtins/DepthOfField.shader
+++ b/PostProcessing/Shaders/Builtins/DepthOfField.shader
@@ -39,7 +39,6 @@ Shader "Hidden/PostProcessing/DepthOfField"
                 #pragma target 5.0
                 #pragma vertex VertDefault
                 #pragma fragment FragPrefilter
-                #pragma multi_compile __ UNITY_COLORSPACE_GAMMA
                 #include "DepthOfField.hlsl"
             ENDHLSL
         }
@@ -171,7 +170,6 @@ Shader "Hidden/PostProcessing/DepthOfField"
                 #pragma target 3.5
                 #pragma vertex VertDefault
                 #pragma fragment FragPrefilter
-                #pragma multi_compile __ UNITY_COLORSPACE_GAMMA
                 #include "DepthOfField.hlsl"
             ENDHLSL
         }

--- a/PostProcessing/Shaders/Builtins/FinalPass.shader
+++ b/PostProcessing/Shaders/Builtins/FinalPass.shader
@@ -2,7 +2,6 @@ Shader "Hidden/PostProcessing/FinalPass"
 {
     HLSLINCLUDE
 
-        #pragma multi_compile __ UNITY_COLORSPACE_GAMMA
         #pragma multi_compile __ FXAA FXAA_LOW
         #pragma multi_compile __ FXAA_KEEP_ALPHA
         #include "../StdLib.hlsl"

--- a/PostProcessing/Shaders/Builtins/ScalableAO.shader
+++ b/PostProcessing/Shaders/Builtins/ScalableAO.shader
@@ -3,8 +3,7 @@ Shader "Hidden/PostProcessing/ScalableAO"
     HLSLINCLUDE
 
         #pragma target 3.0
-        #pragma multi_compile __ UNITY_COLORSPACE_GAMMA
-
+  
     ENDHLSL
 
     SubShader

--- a/PostProcessing/Shaders/Builtins/Uber.shader
+++ b/PostProcessing/Shaders/Builtins/Uber.shader
@@ -4,7 +4,6 @@ Shader "Hidden/PostProcessing/Uber"
 
         #pragma target 3.0
 
-        #pragma multi_compile __ UNITY_COLORSPACE_GAMMA
         #pragma multi_compile __ DISTORT
         #pragma multi_compile __ CHROMATIC_ABERRATION CHROMATIC_ABERRATION_LOW
         #pragma multi_compile __ BLOOM

--- a/PostProcessing/Shaders/Debug/Overlays.shader
+++ b/PostProcessing/Shaders/Debug/Overlays.shader
@@ -5,7 +5,6 @@ Shader "Hidden/PostProcessing/Debug/Overlays"
         #include "../StdLib.hlsl"
         #include "../Colors.hlsl"
         #pragma target 3.0
-        #pragma multi_compile _ UNITY_COLORSPACE_GAMMA
 
         TEXTURE2D_SAMPLER2D(_MainTex, sampler_MainTex);
         TEXTURE2D_SAMPLER2D(_CameraDepthTexture, sampler_CameraDepthTexture);


### PR DESCRIPTION
UNITY_COLORSPACE_GAMMA is a PlatformCapsKeyword, no need to use multi_compile.