### PR TITLE
Use box filter upsample for Bloom in Uber shader if fast mode is enabled

### DIFF
--- a/PostProcessing/Runtime/Effects/Bloom.cs
+++ b/PostProcessing/Runtime/Effects/Bloom.cs
@@ -194,7 +194,10 @@ namespace UnityEngine.Rendering.PostProcessing
 
             // Shader properties
             var uberSheet = context.uberSheet;
-            uberSheet.EnableKeyword("BLOOM");
+            if (settings.fastMode)
+                uberSheet.EnableKeyword("BLOOM_LOW");
+            else
+                uberSheet.EnableKeyword("BLOOM");
             uberSheet.properties.SetVector(ShaderIDs.Bloom_DirtTileOffset, dirtTileOffset);
             uberSheet.properties.SetVector(ShaderIDs.Bloom_Settings, shaderSettings);
             uberSheet.properties.SetColor(ShaderIDs.Bloom_Color, linearColor);

--- a/PostProcessing/Shaders/Builtins/Uber.shader
+++ b/PostProcessing/Shaders/Builtins/Uber.shader
@@ -7,7 +7,7 @@ Shader "Hidden/PostProcessing/Uber"
         #pragma multi_compile __ UNITY_COLORSPACE_GAMMA
         #pragma multi_compile __ DISTORT
         #pragma multi_compile __ CHROMATIC_ABERRATION CHROMATIC_ABERRATION_LOW
-        #pragma multi_compile __ BLOOM
+        #pragma multi_compile __ BLOOM BLOOM_LOW
         #pragma multi_compile __ COLOR_GRADING_LDR_2D COLOR_GRADING_HDR_2D COLOR_GRADING_HDR_3D
         #pragma multi_compile __ VIGNETTE
         #pragma multi_compile __ GRAIN
@@ -141,9 +141,13 @@ Shader "Hidden/PostProcessing/Uber"
 
             color.rgb *= autoExposure;
 
-            #if BLOOM
+            #if BLOOM || BLOOM_LOW
             {
+                #if BLOOM
                 half4 bloom = UpsampleTent(TEXTURE2D_PARAM(_BloomTex, sampler_BloomTex), uvDistorted, _BloomTex_TexelSize.xy, _Bloom_Settings.x);
+                #else
+                half4 bloom = UpsampleBox(TEXTURE2D_PARAM(_BloomTex, sampler_BloomTex), uvDistorted, _BloomTex_TexelSize.xy, _Bloom_Settings.x);
+                #endif
 
                 // UVs should be Distort(uv * _Bloom_DirtTileOffset.xy + _Bloom_DirtTileOffset.zw)
                 // but considering we use a cover-style scale on the dirt texture the difference


### PR DESCRIPTION
v2 uses a more expensive upsample filter for bloom compared to v1 (on mobile).
This adds another keyword BLOOM_LOW, controlled by "Fast Mode" checkbox.