### PR TITLE
cachedData changed from internal to public

### DIFF
--- a/PostProcessing/Runtime/Utils/Spline.cs
+++ b/PostProcessing/Runtime/Utils/Spline.cs
@@ -28,7 +28,7 @@ namespace UnityEngine.Rendering.PostProcessing
 
         // Instead of trying to be smart and blend two curves by generating a new one, we'll simply
         // store the curve data in a float array and blend these instead.
-        internal float[] cachedData;
+        public float[] cachedData;
 
         public Spline(AnimationCurve curve, float zeroValue, bool loop, Vector2 bounds)
         {


### PR DESCRIPTION
Custom Effects that aren't inside Runtime directory aren't allowed to use cachedData under Unity 2017.3.0f3. Everything works fine under 2017.1, but not in that case. And actually cachedData is the only way to use Spline since even buit-in ColorGrading.cs does it.