### PR TITLE
Reduce UI confusion by using ShurikenToggle instead

### DIFF
--- a/PostProcessing/Editor/Utils/Styling.cs
+++ b/PostProcessing/Editor/Utils/Styling.cs
@@ -21,7 +21,7 @@ namespace UnityEditor.Rendering.PostProcessing
 
         static Styling()
         {
-            smallTickbox = new GUIStyle("ShurikenCheckMark");
+            smallTickbox = new GUIStyle("ShurikenToggle");
 
             miniLabelButton = new GUIStyle(EditorStyles.miniLabel);
             miniLabelButton.normal = new GUIStyleState


### PR DESCRIPTION
Constantly seeing people on various discussion boards asking how to enable control of effect settings. The little flat colored bulletpoint dots currently being used goes against general user experience with other applications, including Unity. 
There is little indication that they are actual toggles instead of just "bullet points" and thus confusing users. Either a new style of dot needs to be made similar to "Radio" buttons, or something more readily recognizable like this small square toggle box should be used which falls in line with toggling on the rest of Unity UI. I would also highly suggest the toggles get highlighted when you hover over them, to further help make the UI experience intuitive and reactive.

If Unity wants to switch to circular toggles for most things, that should be done in one broad sweep, not incrementally; to keep things consistent.