### PR TITLE
Fix Bloom "wobble"

### DIFF
--- a/PostProcessing/Runtime/Effects/Bloom.cs
+++ b/PostProcessing/Runtime/Effects/Bloom.cs
@@ -104,10 +104,15 @@ namespace UnityEngine.Rendering.PostProcessing
             float rw = ratio < 0 ? -ratio : 0f;
             float rh = ratio > 0 ?  ratio : 0f;
 
+            // Stereo double-wide
+            var camera = context.camera;
+            int screenWidth = camera.pixelWidth * (RuntimeUtilities.isSinglePassStereoEnabled ? 2 : 1);
+            int screenHeight = camera.pixelHeight;
+
             // Do bloom on a half-res buffer, full-res doesn't bring much and kills performances on
             // fillrate limited platforms
-            int tw = Mathf.FloorToInt(context.screenWidth / (2f - rw));
-            int th = Mathf.FloorToInt(context.screenHeight / (2f - rh));
+            int tw = Mathf.FloorToInt(screenWidth / (2f - rw));
+            int th = Mathf.FloorToInt(screenHeight / (2f - rh));
 
             // Determine the iteration count
             int s = Mathf.Max(tw, th);

--- a/PostProcessing/Runtime/Effects/Bloom.cs
+++ b/PostProcessing/Runtime/Effects/Bloom.cs
@@ -127,21 +127,55 @@ namespace UnityEngine.Rendering.PostProcessing
 
             // Downsample
             var lastDown = context.source;
-            for (int i = 0; i < iterations; i++)
+            if (!settings.fastMode && SystemInfo.supportsComputeShaders)
             {
-                int mipDown = m_Pyramid[i].down;
-                int mipUp = m_Pyramid[i].up;
-                int pass = i == 0
-                    ? (int)Pass.Prefilter13 + qualityOffset
-                    : (int)Pass.Downsample13 + qualityOffset;
+                var compute = context.resources.computeShaders.gaussianDownsample;
+                int kernelMain = compute.FindKernel("KMain");
+                int kernelPrefilter = compute.FindKernel("KMainPreFilter");
+                
+                for (int i = 0; i < iterations; i++)
+                {
+                    int mipDown = m_Pyramid[i].down;
+                    int mipUp = m_Pyramid[i].up;
+                    int kernel = i == 0 ? kernelPrefilter : kernelMain;
 
-                context.GetScreenSpaceTemporaryRT(cmd, mipDown, 0, context.sourceFormat, RenderTextureReadWrite.Default, FilterMode.Bilinear, tw, th);
-                context.GetScreenSpaceTemporaryRT(cmd, mipUp, 0, context.sourceFormat, RenderTextureReadWrite.Default, FilterMode.Bilinear, tw, th);
-                cmd.BlitFullscreenTriangle(lastDown, mipDown, sheet, pass);
+                    cmd.GetTemporaryRT(mipDown, tw, th, 0, FilterMode.Bilinear, context.sourceFormat, RenderTextureReadWrite.Default, 1, true);
+                    cmd.GetTemporaryRT(mipUp, tw, th, 0, FilterMode.Bilinear, context.sourceFormat, RenderTextureReadWrite.Default, 1, true);
 
-                lastDown = mipDown;
-                tw = Mathf.Max(tw / 2, 1);
-                th = Mathf.Max(th / 2, 1);
+                    if (i == 0)
+                    {
+                        cmd.SetComputeVectorParam(compute, "_Threshold", threshold);
+                        cmd.SetComputeTextureParam(compute, kernel, "_AutoExposureTex", context.autoExposureTexture);
+                    }
+
+                    cmd.SetComputeTextureParam(compute, kernel, "_Source", lastDown);
+                    cmd.SetComputeTextureParam(compute, kernel, "_Result", mipDown);
+                    cmd.SetComputeVectorParam(compute, "_Size", new Vector4(tw, th, 1f / tw, 1f / th));
+                    cmd.DispatchCompute(compute, kernel, (tw + 7) / 8, (th + 7) / 8, 1);
+
+                    lastDown = mipDown;
+                    tw = Mathf.Max(tw / 2, 1);
+                    th = Mathf.Max(th / 2, 1);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < iterations; i++)
+                {
+                    int mipDown = m_Pyramid[i].down;
+                    int mipUp = m_Pyramid[i].up;
+                    int pass = i == 0
+                        ? (int)Pass.Prefilter13 + qualityOffset
+                        : (int)Pass.Downsample13 + qualityOffset;
+
+                    context.GetScreenSpaceTemporaryRT(cmd, mipDown, 0, context.sourceFormat, RenderTextureReadWrite.Default, FilterMode.Bilinear, tw, th);
+                    context.GetScreenSpaceTemporaryRT(cmd, mipUp, 0, context.sourceFormat, RenderTextureReadWrite.Default, FilterMode.Bilinear, tw, th);
+                    cmd.BlitFullscreenTriangle(lastDown, mipDown, sheet, pass);
+
+                    lastDown = mipDown;
+                    tw = Mathf.Max(tw / 2, 1);
+                    th = Mathf.Max(th / 2, 1);
+                }
             }
 
             // Upsample

--- a/PostProcessing/Shaders/Builtins/GaussianDownsample.compute
+++ b/PostProcessing/Shaders/Builtins/GaussianDownsample.compute
@@ -23,14 +23,18 @@
 #pragma exclude_renderers gles gles3 d3d11_9x
 
 #include "../StdLib.hlsl"
+#include "../Colors.hlsl"
 
 Texture2D<float4> _Source;
 RWTexture2D<float4> _Result;
 
 SamplerState sampler_LinearClamp;
 
+TEXTURE2D_SAMPLER2D(_AutoExposureTex, sampler_AutoExposureTex);
+
 CBUFFER_START(cb)
     float4 _Size;
+    float4 _Threshold;
 CBUFFER_END
 
 // 16x16 pixels with an 8x8 center that we will be blurring writing out. Each uint is two color
@@ -96,7 +100,7 @@ void BlurHorizontally(uint outIndex, uint leftMostIndex)
     Store1Pixel(outIndex + 1, BlurPixels(s1, s2, s3, s4, s5, s6, s7, s8, s9));
 }
 
-void BlurVertically(uint2 pixelCoord, uint topMostIndex)
+void BlurVertically(uint2 pixelCoord, uint topMostIndex, float autoExposure)
 {
     float4 s0, s1, s2, s3, s4, s5, s6, s7, s8;
     Load1Pixel(topMostIndex     , s0);
@@ -111,30 +115,45 @@ void BlurVertically(uint2 pixelCoord, uint topMostIndex)
 
     float4 blurred = BlurPixels(s0, s1, s2, s3, s4, s5, s6, s7, s8);
 
+    // Pre-filter if needed
+#if BLOOM_PRE_FILTER
+    blurred = SafeHDR(blurred);
+    blurred *= autoExposure;
+    blurred = QuadraticThreshold(blurred, _Threshold.x, _Threshold.yzw);
+#endif
+
     // Write to the final target
     _Result[pixelCoord] = blurred;
 }
 
-#pragma kernel KMain
+#pragma kernel KMain          KERNEL=KMain          BLOOM_PRE_FILTER=0
+#pragma kernel KMainPreFilter KERNEL=KMainPreFilter BLOOM_PRE_FILTER=1
 
 #ifdef DISABLE_COMPUTE_SHADERS
 
-TRIVIAL_COMPUTE_KERNEL(KMain)
+TRIVIAL_COMPUTE_KERNEL(KERNEL)
 
 #else
 
 [numthreads(8, 8, 1)]
-void KMain(uint2 groupId : SV_GroupID, uint2 groupThreadId : SV_GroupThreadID, uint2 dispatchThreadId : SV_DispatchThreadID)
+void KERNEL(uint2 groupId : SV_GroupID, uint2 groupThreadId : SV_GroupThreadID, uint2 dispatchThreadId : SV_DispatchThreadID)
 {
     // Upper-left pixel coordinate of quad that this thread will read
     int2 threadUL = (groupThreadId << 1) + (groupId << 3) - 4;
 
     // Downsample the block
     float2 offset = float2(threadUL);
+
     float4 p00 = _Source.SampleLevel(sampler_LinearClamp, (offset                    + 0.5) * _Size.zw, 0.0);
     float4 p10 = _Source.SampleLevel(sampler_LinearClamp, (offset + float2(1.0, 0.0) + 0.5) * _Size.zw, 0.0);
     float4 p01 = _Source.SampleLevel(sampler_LinearClamp, (offset + float2(0.0, 1.0) + 0.5) * _Size.zw, 0.0);
     float4 p11 = _Source.SampleLevel(sampler_LinearClamp, (offset + float2(1.0, 1.0) + 0.5) * _Size.zw, 0.0);
+
+#if BLOOM_PRE_FILTER
+    float autoExposure = _AutoExposureTex.SampleLevel(sampler_LinearClamp, (offset + 0.5) * _Size.xy, 0.0).r;
+#else
+    float autoExposure = 0;
+#endif
 
     // Store the 4 downsampled pixels in LDS
     uint destIdx = groupThreadId.x + (groupThreadId.y << 4u);
@@ -150,7 +169,7 @@ void KMain(uint2 groupId : SV_GroupID, uint2 groupThreadId : SV_GroupThreadID, u
     GroupMemoryBarrierWithGroupSync();
 
     // Vertically blur the pixels in LDS and write the result to memory
-    BlurVertically(dispatchThreadId, (groupThreadId.y << 3u) + groupThreadId.x);
+    BlurVertically(dispatchThreadId, (groupThreadId.y << 3u) + groupThreadId.x, autoExposure);
 }
 
 #endif // DISABLE_COMPUTE_SHADERS


### PR DESCRIPTION
This just re-purposes SSR's Gaussian down-sampling for Bloom. The current shader causes severe wobbling when the camera moves, and in XR this is extremely amplified (unusable).  The Gaussian down-sampler doesn't suffer from this problem.