### PR TITLE
Fix lerp of 3D textures against default texture params

### DIFF
--- a/PostProcessing/Runtime/ParameterOverride.cs
+++ b/PostProcessing/Runtime/ParameterOverride.cs
@@ -249,16 +249,24 @@ namespace UnityEngine.Rendering.PostProcessing
             {
                 Texture defaultTexture;
 
+                bool is3d = false;
+                if(to != null)
+                    is3d = to is Texture3D
+                            || (to is RenderTexture && ((RenderTexture)to).volumeDepth > 1);
+                else
+                    is3d = from is Texture3D
+                            || (from is RenderTexture && ((RenderTexture)from).volumeDepth > 1);
+
                 switch (defaultState)
                 {
                     case TextureParameterDefault.Black:
-                        defaultTexture = RuntimeUtilities.blackTexture;
+                        defaultTexture = is3d ? (Texture)RuntimeUtilities.blackTexture3D : RuntimeUtilities.blackTexture;
                         break;
                     case TextureParameterDefault.White:
-                        defaultTexture = RuntimeUtilities.whiteTexture;
+                        defaultTexture = is3d ? (Texture)RuntimeUtilities.whiteTexture3D : RuntimeUtilities.whiteTexture;
                         break;
                     case TextureParameterDefault.Transparent:
-                        defaultTexture = RuntimeUtilities.transparentTexture;
+                        defaultTexture = is3d ? (Texture)RuntimeUtilities.transparentTexture3D : RuntimeUtilities.transparentTexture;
                         break;
                     case TextureParameterDefault.Lut2D:
                         // Find the current lut size

--- a/PostProcessing/Runtime/Utils/RuntimeUtilities.cs
+++ b/PostProcessing/Runtime/Utils/RuntimeUtilities.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -34,6 +34,21 @@ namespace UnityEngine.Rendering.PostProcessing
                 return m_WhiteTexture;
             }
         }
+        static Texture3D m_WhiteTexture3D;
+        public static Texture3D whiteTexture3D
+        {
+            get
+            {
+                if (m_WhiteTexture3D == null)
+                {
+                    m_WhiteTexture3D = new Texture3D(1, 1, 1, TextureFormat.ARGB32, false) { name = "White Texture 3D" };
+                    m_WhiteTexture3D.SetPixels(new Color[] { Color.white });
+                    m_WhiteTexture3D.Apply();
+                }
+
+                return m_WhiteTexture3D;
+            }
+        }
 
         static Texture2D m_BlackTexture;
         public static Texture2D blackTexture
@@ -51,6 +66,22 @@ namespace UnityEngine.Rendering.PostProcessing
             }
         }
 
+        static Texture3D m_BlackTexture3D;
+        public static Texture3D blackTexture3D
+        {
+            get
+            {
+                if (m_BlackTexture3D == null)
+                {
+                    m_BlackTexture3D = new Texture3D(1, 1, 1, TextureFormat.ARGB32, false) { name = "Black Texture 3D" };
+                    m_BlackTexture3D.SetPixels(new Color[] { Color.black });
+                    m_BlackTexture3D.Apply();
+                }
+
+                return m_BlackTexture3D;
+            }
+        }
+
         static Texture2D m_TransparentTexture;
         public static Texture2D transparentTexture
         {
@@ -64,6 +95,22 @@ namespace UnityEngine.Rendering.PostProcessing
                 }
 
                 return m_TransparentTexture;
+            }
+        }
+
+        static Texture3D m_TransparentTexture3D;
+        public static Texture3D transparentTexture3D
+        {
+            get
+            {
+                if (m_TransparentTexture3D == null)
+                {
+                    m_TransparentTexture3D = new Texture3D(1, 1, 1, TextureFormat.ARGB32, false) { name = "Transparent Texture 3D" };
+                    m_TransparentTexture3D.SetPixels(new Color[] { Color.clear });
+                    m_TransparentTexture3D.Apply();
+                }
+
+                return m_TransparentTexture3D;
             }
         }
 


### PR DESCRIPTION
When a 3D texture is getting interpolated against TextureParameterDefault, the lerp would try to bind a 2d texture in place of a 3D texture. This breaks Vulkan and possibly other APIs as well, so use a separate 3D black/white/transparent textures for that purpose