### PR TITLE
Refactor texture lerp to work properly with solid colors

### DIFF
--- a/PostProcessing/Runtime/Utils/ShaderIDs.cs
+++ b/PostProcessing/Runtime/Utils/ShaderIDs.cs
@@ -141,6 +141,7 @@ namespace UnityEngine.Rendering.PostProcessing
         internal static readonly int From                            = Shader.PropertyToID("_From");
         internal static readonly int To                              = Shader.PropertyToID("_To");
         internal static readonly int Interp                          = Shader.PropertyToID("_Interp");
+        internal static readonly int TargetColor                     = Shader.PropertyToID("_TargetColor");
 
         internal static readonly int HalfResFinalCopy                = Shader.PropertyToID("_HalfResFinalCopy");
         internal static readonly int WaveformSource                  = Shader.PropertyToID("_WaveformSource");

--- a/PostProcessing/Runtime/Utils/TextureLerper.cs
+++ b/PostProcessing/Runtime/Utils/TextureLerper.cs
@@ -59,7 +59,7 @@ namespace UnityEngine.Rendering.PostProcessing
             }
         }
 
-        RenderTexture Get(RenderTextureFormat format, int w, int h, int d = 1, bool enableRandomWrite = false)
+        RenderTexture Get(RenderTextureFormat format, int w, int h, int d = 1, bool enableRandomWrite = false, bool force3D = false)
         {
             RenderTexture rt = null;
             int i, len = m_Recycled.Count;
@@ -67,7 +67,7 @@ namespace UnityEngine.Rendering.PostProcessing
             for (i = 0; i < len; i++)
             {
                 var r = m_Recycled[i];
-                if (r.width == w && r.height == h && r.volumeDepth == d && r.format == format && r.enableRandomWrite == enableRandomWrite)
+                if (r.width == w && r.height == h && r.volumeDepth == d && r.format == format && r.enableRandomWrite == enableRandomWrite && (!force3D || (r.dimension == TextureDimension.Tex3D)))
                 {
                     rt = r;
                     break;
@@ -76,7 +76,7 @@ namespace UnityEngine.Rendering.PostProcessing
 
             if (rt == null)
             {
-                var dimension = d > 1
+                var dimension = (d > 1) || force3D
                     ? TextureDimension.Tex3D
                     : TextureDimension.Tex2D;
 
@@ -101,31 +101,36 @@ namespace UnityEngine.Rendering.PostProcessing
         {
             Assert.IsNotNull(from);
             Assert.IsNotNull(to);
+            Assert.AreEqual(from.width, to.width);
+            Assert.AreEqual(from.height, to.height);
 
             // Saves a potentially expensive fullscreen blit when using dirt textures & the likes
             if (from == to)
                 return from;
 
-            bool is3d = to is Texture3D
-                    || (to is RenderTexture && ((RenderTexture)to).volumeDepth > 1);
+            bool is3D = from is Texture3D
+                    || (from is RenderTexture && ((RenderTexture)from).volumeDepth > 1);
 
             RenderTexture rt;
 
             // 3D texture blending is a special case and only works on compute enabled platforms
-            if (is3d)
+            if (is3D)
             {
-                int size = to.width;
-                rt = Get(RenderTextureFormat.ARGBHalf, size, size, size, true);
+                int dpth = @from is Texture3D ? ((Texture3D) @from).depth : ((RenderTexture) @from).volumeDepth;
+                int size = Math.Max(from.width, from.height);
+                size = Math.Max(size, dpth);
+                
+                rt = Get(RenderTextureFormat.ARGBHalf, from.width, from.height, dpth, true, true);
 
                 var compute = m_Resources.computeShaders.texture3dLerp;
                 int kernel = compute.FindKernel("KTexture3DLerp");
-                m_Command.SetComputeVectorParam(compute, "_Params", new Vector4(t, size, 0f, 0f));
+                m_Command.SetComputeVectorParam(compute, "_DimensionsAndLerp", new Vector4(from.width, from.height, dpth, t));
                 m_Command.SetComputeTextureParam(compute, kernel, "_Output", rt);
                 m_Command.SetComputeTextureParam(compute, kernel, "_From", from);
                 m_Command.SetComputeTextureParam(compute, kernel, "_To", to);
 
                 int groupSizeXY = Mathf.CeilToInt(size / 8f);
-                int groupSizeZ = Mathf.CeilToInt(size / (RuntimeUtilities.isAndroidOpenGL ? 2f : 8f));
+                int groupSizeZ = Mathf.CeilToInt(size / 8f);
                 m_Command.DispatchCompute(compute, kernel, groupSizeXY, groupSizeXY, groupSizeZ);
                 return rt;
             }
@@ -149,6 +154,60 @@ namespace UnityEngine.Rendering.PostProcessing
             return rt;
         }
 
+        internal Texture Lerp(Texture from, Color to, float t)
+        {
+            Assert.IsNotNull(from);
+
+            if (t < 0.00001)
+                return from;
+
+            bool is3D = from is Texture3D
+                    || (from is RenderTexture && ((RenderTexture)from).volumeDepth > 1);
+
+            RenderTexture rt;
+
+            // 3D texture blending is a special case and only works on compute enabled platforms
+            if (is3D)
+            {
+                int dpth = @from is Texture3D ? ((Texture3D) @from).depth : ((RenderTexture) @from).volumeDepth;
+                int size = Math.Max(from.width, from.height);
+                size = Math.Max(size, dpth);
+                
+                rt = Get(RenderTextureFormat.ARGBHalf, from.width, from.height, dpth, true, true);
+
+                var compute = m_Resources.computeShaders.texture3dLerp;
+                int kernel = compute.FindKernel("KTexture3DLerpToColor");
+                m_Command.SetComputeVectorParam(compute, "_DimensionsAndLerp", new Vector4(from.width, from.height, dpth, t));
+                m_Command.SetComputeVectorParam(compute, "_TargetColor", new Vector4(to.r, to.g, to.b, to.a));
+                m_Command.SetComputeTextureParam(compute, kernel, "_Output", rt);
+                m_Command.SetComputeTextureParam(compute, kernel, "_From", from);
+
+                int groupSizeXY = Mathf.CeilToInt(size / 8f);
+                int groupSizeZ = Mathf.CeilToInt(size / 8f);
+                m_Command.DispatchCompute(compute, kernel, groupSizeXY, groupSizeXY, groupSizeZ);
+                return rt;
+            }
+
+            // 2D texture blending
+            // We could handle textures with different sizes by picking the biggest one to avoid
+            // popping effects. This would work in most cases but will still pop if one texture is
+            // wider but shorter than the other. Generally speaking you're expected to use same-size
+            // textures anyway so we decided not to handle this case at the moment, especially since
+            // it would waste a lot of texture memory as soon as you start using bigger textures
+            // (snow ball effect).
+            var format = TextureFormatUtilities.GetUncompressedRenderTextureFormat(from);
+            rt = Get(format, from.width, from.height);
+
+            var sheet = m_PropertySheets.Get(m_Resources.shaders.texture2dLerp);
+            sheet.properties.SetVector(ShaderIDs.TargetColor, new Vector4(to.r, to.g, to.b, to.a));
+            sheet.properties.SetFloat(ShaderIDs.Interp, t);
+
+            m_Command.BlitFullscreenTriangle(from, rt, sheet, 1);
+
+            return rt;
+        }
+        
+        
         internal void Clear()
         {
             foreach (var rt in m_Actives)

--- a/PostProcessing/Runtime/Utils/TextureLerper.cs
+++ b/PostProcessing/Runtime/Utils/TextureLerper.cs
@@ -117,8 +117,8 @@ namespace UnityEngine.Rendering.PostProcessing
             if (is3D)
             {
                 int dpth = @from is Texture3D ? ((Texture3D) @from).depth : ((RenderTexture) @from).volumeDepth;
-                int size = Math.Max(from.width, from.height);
-                size = Math.Max(size, dpth);
+                int size = Mathf.Max(from.width, from.height);
+                size = Mathf.Max(size, dpth);
                 
                 rt = Get(RenderTextureFormat.ARGBHalf, from.width, from.height, dpth, true, true);
 
@@ -170,8 +170,8 @@ namespace UnityEngine.Rendering.PostProcessing
             if (is3D)
             {
                 int dpth = @from is Texture3D ? ((Texture3D) @from).depth : ((RenderTexture) @from).volumeDepth;
-                int size = Math.Max(from.width, from.height);
-                size = Math.Max(size, dpth);
+                int size = Mathf.Max(from.width, from.height);
+                size = Mathf.Max(size, dpth);
                 
                 rt = Get(RenderTextureFormat.ARGBHalf, from.width, from.height, dpth, true, true);
 

--- a/PostProcessing/Shaders/Builtins/Texture2DLerp.shader
+++ b/PostProcessing/Shaders/Builtins/Texture2DLerp.shader
@@ -7,6 +7,7 @@ Shader "Hidden/PostProcessing/Texture2DLerp"
         TEXTURE2D_SAMPLER2D(_MainTex, sampler_MainTex); // From
         TEXTURE2D_SAMPLER2D(_To, sampler_To);
         float _Interp;
+        float4 _TargetColor;
 
         float4 Frag(VaryingsDefault i) : SV_Target
         {
@@ -15,6 +16,12 @@ Shader "Hidden/PostProcessing/Texture2DLerp"
             return lerp(from, to, _Interp);
         }
 
+        float4 FragColor(VaryingsDefault i) : SV_Target
+        {
+            float4 from = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.texcoord);
+            float4 to = _TargetColor;
+            return lerp(from, to, _Interp);
+        }
     ENDHLSL
 
     SubShader
@@ -27,6 +34,15 @@ Shader "Hidden/PostProcessing/Texture2DLerp"
 
                 #pragma vertex VertDefault
                 #pragma fragment Frag
+
+            ENDHLSL
+        }
+        Pass
+        {
+            HLSLPROGRAM
+
+                #pragma vertex VertDefault
+                #pragma fragment FragColor
 
             ENDHLSL
         }

--- a/PostProcessing/Shaders/Builtins/Texture3DLerp.compute
+++ b/PostProcessing/Shaders/Builtins/Texture3DLerp.compute
@@ -4,11 +4,13 @@
 #include "../StdLib.hlsl"
 
 #pragma kernel KTexture3DLerp
+#pragma kernel KTexture3DLerpToColor
 
 RWTexture3D<float4> _Output;
 
 CBUFFER_START(Params)
-    float4 _Params; // x: lerp factor, y: lut size, zw: unused
+    float4 _DimensionsAndLerp; // xyz: surface dimensions, w: lerp factor
+    float4 _TargetColor; // Color to lerp into
 CBUFFER_END
 
 Texture3D _From;
@@ -19,17 +21,29 @@ Texture3D _To;
 #ifdef DISABLE_COMPUTE_SHADERS
 
 TRIVIAL_COMPUTE_KERNEL(KTexture3DLerp)
+TRIVIAL_COMPUTE_KERNEL(KTexture3DLerpToColor)
 
 #else
 
 [numthreads(GROUP_SIZE, GROUP_SIZE, GROUP_SIZE)]
 void KTexture3DLerp(uint3 id : SV_DispatchThreadID)
 {
-    if (float(id.x) < _Params.y && float(id.y) < _Params.y && float(id.z) < _Params.y)
+    if(all(float3(id) < _DimensionsAndLerp.xyz))
     {
-        float3 from = _From[id].rgb;
-        float3 to = _To[id].rgb;
-        _Output[id] = float4(lerp(from, to, _Params.xxx), 1.0);
+        float4 from = _From[id];
+        float4 to = _To[id];
+        _Output[id] = lerp(from, to, _DimensionsAndLerp.wwww);
+    }
+}
+
+[numthreads(GROUP_SIZE, GROUP_SIZE, GROUP_SIZE)]
+void KTexture3DLerpToColor(uint3 id : SV_DispatchThreadID)
+{
+    if(all(float3(id) < _DimensionsAndLerp.xyz))
+    {
+        float4 from = _From[id];
+        float4 to = _TargetColor;
+        _Output[id] = lerp(from, to, _DimensionsAndLerp.wwww);
     }
 }
 


### PR DESCRIPTION
Turns out lerping to and from 1x1(x1) textures doesn't really do anything as the output gets clamped into that size. This PR implements lerping from TextureParameterDefaults properly, also taking alpha into account in both 3d and 2d cases.