### PR TITLE
V2 - Fix threadgroup size warning on MacOS Metal

### DIFF
--- a/PostProcessing/Runtime/Effects/ColorGrading.cs
+++ b/PostProcessing/Runtime/Effects/ColorGrading.cs
@@ -238,7 +238,7 @@ namespace UnityEngine.Rendering.PostProcessing
                 }
 
                 int groupSizeXY = Mathf.CeilToInt(k_Lut3DSize / 8f);
-                int groupSizeZ = Mathf.CeilToInt(k_Lut3DSize / (RuntimeUtilities.isAndroidOpenGL ? 2f : 8f));
+                int groupSizeZ = Mathf.CeilToInt(k_Lut3DSize / (RuntimeUtilities.isAndroidOpenGL || RuntimeUtilities.isOSXMetal ? 2f : 8f));
                 var cmd = context.command;
                 cmd.SetComputeTextureParam(compute, kernel, "_Output", m_InternalLogLut);
                 cmd.SetComputeVectorParam(compute, "_Size", new Vector4(k_Lut3DSize, 1f / (k_Lut3DSize - 1f), 0f, 0f));
@@ -289,6 +289,9 @@ namespace UnityEngine.Rendering.PostProcessing
                 }
 
                 // Generate the lut
+                uint tx, ty, tz = 0;
+                compute.GetKernelThreadGroupSizes(kernel, out tx, out ty, out tz);
+                //Debug.LogFormat("Size: {0} {1} {2}", tx, ty, tz);
                 context.command.BeginSample("HdrColorGradingLut3D");
                 cmd.DispatchCompute(compute, kernel, groupSizeXY, groupSizeXY, groupSizeZ);
                 context.command.EndSample("HdrColorGradingLut3D");

--- a/PostProcessing/Runtime/Utils/RuntimeUtilities.cs
+++ b/PostProcessing/Runtime/Utils/RuntimeUtilities.cs
@@ -433,6 +433,12 @@ namespace UnityEngine.Rendering.PostProcessing
             get { return Application.platform == RuntimePlatform.Android && SystemInfo.graphicsDeviceType != GraphicsDeviceType.Vulkan; }
         }
 
+        public static bool isOSXMetal
+        {
+                get { return Application.platform == RuntimePlatform.OSXEditor || Application.platform == RuntimePlatform.OSXPlayer
+                             && SystemInfo.graphicsDeviceType == GraphicsDeviceType.Metal; }
+        }
+
         public static RenderTextureFormat defaultHDRRenderTextureFormat
         {
             get

--- a/PostProcessing/Runtime/Utils/TextureLerper.cs
+++ b/PostProcessing/Runtime/Utils/TextureLerper.cs
@@ -130,7 +130,7 @@ namespace UnityEngine.Rendering.PostProcessing
                 m_Command.SetComputeTextureParam(compute, kernel, "_To", to);
 
                 int groupSizeXY = Mathf.CeilToInt(size / 8f);
-                int groupSizeZ = Mathf.CeilToInt(size / 8f);
+                int groupSizeZ = Mathf.CeilToInt(size / (RuntimeUtilities.isOSXMetal ? 2f : 8f));
                 m_Command.DispatchCompute(compute, kernel, groupSizeXY, groupSizeXY, groupSizeZ);
                 return rt;
             }

--- a/PostProcessing/Shaders/Builtins/Lut3DBaker.compute
+++ b/PostProcessing/Shaders/Builtins/Lut3DBaker.compute
@@ -151,7 +151,7 @@ void Eval(uint3 id)
     }
 }
 
-#ifdef SHADER_API_GLES3
+#if defined(SHADER_API_GLES3) || defined(SHADER_API_METAL)
     #define GROUP_SIZE_XY 8
     #define GROUP_SIZE_Z 2
 #else

--- a/PostProcessing/Shaders/Builtins/Texture3DLerp.compute
+++ b/PostProcessing/Shaders/Builtins/Texture3DLerp.compute
@@ -16,7 +16,13 @@ CBUFFER_END
 Texture3D _From;
 Texture3D _To;
 
-#define GROUP_SIZE 8
+#ifdef SHADER_API_METAL
+    #define GROUP_SIZE_XY 8
+    #define GROUP_SIZE_Z 2
+#else
+    #define GROUP_SIZE_XY 8
+    #define GROUP_SIZE_Z 8
+#endif
 
 #ifdef DISABLE_COMPUTE_SHADERS
 
@@ -25,7 +31,7 @@ TRIVIAL_COMPUTE_KERNEL(KTexture3DLerpToColor)
 
 #else
 
-[numthreads(GROUP_SIZE, GROUP_SIZE, GROUP_SIZE)]
+[numthreads(GROUP_SIZE_XY, GROUP_SIZE_XY, GROUP_SIZE_Z)]
 void KTexture3DLerp(uint3 id : SV_DispatchThreadID)
 {
     if(all(float3(id) < _DimensionsAndLerp.xyz))
@@ -36,7 +42,7 @@ void KTexture3DLerp(uint3 id : SV_DispatchThreadID)
     }
 }
 
-[numthreads(GROUP_SIZE, GROUP_SIZE, GROUP_SIZE)]
+[numthreads(GROUP_SIZE_XY, GROUP_SIZE_XY, GROUP_SIZE_Z)]
 void KTexture3DLerpToColor(uint3 id : SV_DispatchThreadID)
 {
     if(all(float3(id) < _DimensionsAndLerp.xyz))


### PR DESCRIPTION
Fix for #580

Summary:
- Add runtime utilities property to query if using Metal on MacOS
- Reduced lerp & LUT threadgroup size on MacOS Metal to stay under threadgroup size limit