### PR TITLE
Fix screen space reflection memory/resource ID leak

### DIFF
--- a/PostProcessing/Runtime/Effects/ScreenSpaceReflections.cs
+++ b/PostProcessing/Runtime/Effects/ScreenSpaceReflections.cs
@@ -101,7 +101,10 @@ namespace UnityEngine.Rendering.PostProcessing
             if (rt == null || !rt.IsCreated() || rt.width != width || rt.height != height || rt.format != format)
             {
                 if (rt != null)
+                {
                     rt.Release();
+                    RuntimeUtilities.Destroy(rt);
+                }
 
                 rt = new RenderTexture(width, height, 0, format)
                 {


### PR DESCRIPTION
Properly cleans up Render Texture re-creation during screen space reflection render passes.
Seems to fix issue https://github.com/Unity-Technologies/PostProcessing/issues/643.