### PR TITLE
Bloom fixes for single-pass double-wide stereo rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Compilation issue with Unity 2019.1.
 - Screen-space reflection memory leak.
 - Bloom flicker in single-pass double-wide stereo rendering
+- Right eye bloom offset in single-pass double-wide stereo rendering
 
 ## [2.0.12-preview]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Compilation issue with Unity 2019.1.
 - Screen-space reflection memory leak.
+- Bloom flicker in single-pass double-wide stereo rendering
 
 ## [2.0.12-preview]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.0.14-preview]
 
+### Fixed
+- Bloom flicker in single-pass double-wide stereo rendering.
+- Right eye bloom offset in single-pass double-wide stereo rendering.
+
 ## [2.0.13-preview]
 
 ### Fixed
 - Compilation issue with Unity 2019.1.
 - Screen-space reflection memory leak.
-- Bloom flicker in single-pass double-wide stereo rendering
-- Right eye bloom offset in single-pass double-wide stereo rendering
 
 ## [2.0.12-preview]
 

--- a/PostProcessing/Runtime/Effects/Bloom.cs
+++ b/PostProcessing/Runtime/Effects/Bloom.cs
@@ -116,13 +116,10 @@ namespace UnityEngine.Rendering.PostProcessing
             bool singlePassDoubleWide = (context.stereoActive && (context.camera.stereoTargetEye == StereoTargetEyeMask.Both));
             int s = Mathf.Max(tw, th);
             float logs = Mathf.Log(s, 2f) + Mathf.Min(settings.diffusion.value, 10f) - 10f;
-            int logs_i = Mathf.FloorToInt(logs) - (singlePassDoubleWide ? 2 : 0); // Don't downsample as much for a double-wide texture
+            int logs_i = Mathf.FloorToInt(logs); 
             int iterations = Mathf.Clamp(logs_i, 1, k_MaxPyramidSize);
             float sampleScale = 0.5f + logs - logs_i;
-            float sampleScaleX = (singlePassDoubleWide ? sampleScale * 0.5f : sampleScale);
-            Vector4 sampleScaleVec = new Vector4(sampleScaleX, sampleScale, sampleScaleX, sampleScale);
-            sheet.properties.SetVector(ShaderIDs.SampleScale, sampleScaleVec);
-            //sheet.properties.SetFloat(ShaderIDs.SampleScale, sampleScale);
+            sheet.properties.SetFloat(ShaderIDs.SampleScale, sampleScale);
 
             // Prefiltering parameters
             float lthresh = Mathf.GammaToLinearSpace(settings.threshold.value);

--- a/PostProcessing/Runtime/Effects/Bloom.cs
+++ b/PostProcessing/Runtime/Effects/Bloom.cs
@@ -115,7 +115,7 @@ namespace UnityEngine.Rendering.PostProcessing
             // Determine the iteration count
             int s = Mathf.Max(tw, th);
             float logs = Mathf.Log(s, 2f) + Mathf.Min(settings.diffusion.value, 10f) - 10f;
-            int logs_i = Mathf.FloorToInt(logs);
+            int logs_i = Mathf.FloorToInt(logs) - ((context.stereoActive && (context.camera.stereoTargetEye == StereoTargetEyeMask.Both)) ? 2 : 0); // Don't downsample as much for a double-wide texture
             int iterations = Mathf.Clamp(logs_i, 1, k_MaxPyramidSize);
             float sampleScale = 0.5f + logs - logs_i;
             sheet.properties.SetFloat(ShaderIDs.SampleScale, sampleScale);

--- a/PostProcessing/Runtime/Effects/Bloom.cs
+++ b/PostProcessing/Runtime/Effects/Bloom.cs
@@ -113,12 +113,16 @@ namespace UnityEngine.Rendering.PostProcessing
             int th = Mathf.FloorToInt(context.screenHeight / (2f - rh));
 
             // Determine the iteration count
+            bool singlePassDoubleWide = (context.stereoActive && (context.camera.stereoTargetEye == StereoTargetEyeMask.Both));
             int s = Mathf.Max(tw, th);
             float logs = Mathf.Log(s, 2f) + Mathf.Min(settings.diffusion.value, 10f) - 10f;
-            int logs_i = Mathf.FloorToInt(logs) - ((context.stereoActive && (context.camera.stereoTargetEye == StereoTargetEyeMask.Both)) ? 2 : 0); // Don't downsample as much for a double-wide texture
+            int logs_i = Mathf.FloorToInt(logs) - (singlePassDoubleWide ? 2 : 0); // Don't downsample as much for a double-wide texture
             int iterations = Mathf.Clamp(logs_i, 1, k_MaxPyramidSize);
             float sampleScale = 0.5f + logs - logs_i;
-            sheet.properties.SetFloat(ShaderIDs.SampleScale, sampleScale);
+            float sampleScaleX = (singlePassDoubleWide ? sampleScale * 0.5f : sampleScale);
+            Vector4 sampleScaleVec = new Vector4(sampleScaleX, sampleScale, sampleScaleX, sampleScale);
+            sheet.properties.SetVector(ShaderIDs.SampleScale, sampleScaleVec);
+            //sheet.properties.SetFloat(ShaderIDs.SampleScale, sampleScale);
 
             // Prefiltering parameters
             float lthresh = Mathf.GammaToLinearSpace(settings.threshold.value);

--- a/PostProcessing/Runtime/Effects/Bloom.cs
+++ b/PostProcessing/Runtime/Effects/Bloom.cs
@@ -111,9 +111,10 @@ namespace UnityEngine.Rendering.PostProcessing
             // fillrate limited platforms
             int tw = Mathf.FloorToInt(context.screenWidth / (2f - rw));
             int th = Mathf.FloorToInt(context.screenHeight / (2f - rh));
+            bool singlePassDoubleWide = (context.stereoActive && (context.camera.stereoTargetEye == StereoTargetEyeMask.Both));
+            int tw_stereo = singlePassDoubleWide ? tw * 2 : tw; 
 
             // Determine the iteration count
-            bool singlePassDoubleWide = (context.stereoActive && (context.camera.stereoTargetEye == StereoTargetEyeMask.Both));
             int s = Mathf.Max(tw, th);
             float logs = Mathf.Log(s, 2f) + Mathf.Min(settings.diffusion.value, 10f) - 10f;
             int logs_i = Mathf.FloorToInt(logs); 
@@ -141,12 +142,13 @@ namespace UnityEngine.Rendering.PostProcessing
                     ? (int)Pass.Prefilter13 + qualityOffset
                     : (int)Pass.Downsample13 + qualityOffset;
 
-                context.GetScreenSpaceTemporaryRT(cmd, mipDown, 0, context.sourceFormat, RenderTextureReadWrite.Default, FilterMode.Bilinear, tw, th);
-                context.GetScreenSpaceTemporaryRT(cmd, mipUp, 0, context.sourceFormat, RenderTextureReadWrite.Default, FilterMode.Bilinear, tw, th);
+                context.GetScreenSpaceTemporaryRT(cmd, mipDown, 0, context.sourceFormat, RenderTextureReadWrite.Default, FilterMode.Bilinear, tw_stereo, th);
+                context.GetScreenSpaceTemporaryRT(cmd, mipUp, 0, context.sourceFormat, RenderTextureReadWrite.Default, FilterMode.Bilinear, tw_stereo, th);
                 cmd.BlitFullscreenTriangle(lastDown, mipDown, sheet, pass);
 
                 lastDown = mipDown;
-                tw = Mathf.Max(tw / 2, 1);
+                tw_stereo = (singlePassDoubleWide && ((tw_stereo / 2) % 2 > 0)) ? 1 + tw_stereo / 2 : tw_stereo / 2;
+                tw_stereo = Mathf.Max(tw_stereo, 1);
                 th = Mathf.Max(th / 2, 1);
             }
 

--- a/PostProcessing/Shaders/Builtins/Bloom.shader
+++ b/PostProcessing/Shaders/Builtins/Bloom.shader
@@ -31,7 +31,7 @@ Shader "Hidden/PostProcessing/Bloom"
         half4 FragPrefilter13(VaryingsDefault i) : SV_Target
         {
             half4 color = DownsampleBox13Tap(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, UnityStereoAdjustedTexelSize(_MainTex_TexelSize).xy);
-            return Prefilter(SafeHDR(color), i.texcoord);
+			return Prefilter(SafeHDR(color), i.texcoord);
         }
 
         half4 FragPrefilter4(VaryingsDefault i) : SV_Target
@@ -46,7 +46,7 @@ Shader "Hidden/PostProcessing/Bloom"
         half4 FragDownsample13(VaryingsDefault i) : SV_Target
         {
             half4 color = DownsampleBox13Tap(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, UnityStereoAdjustedTexelSize(_MainTex_TexelSize).xy);
-            return color;
+			return color;
         }
 
         half4 FragDownsample4(VaryingsDefault i) : SV_Target
@@ -67,13 +67,13 @@ Shader "Hidden/PostProcessing/Bloom"
         half4 FragUpsampleTent(VaryingsDefault i) : SV_Target
         {
             half4 bloom = UpsampleTent(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, UnityStereoAdjustedTexelSize(_MainTex_TexelSize).xy, _SampleScale);
-            return Combine(bloom, i.texcoordStereo);
+			return Combine(bloom, i.texcoordStereo);
         }
 
         half4 FragUpsampleBox(VaryingsDefault i) : SV_Target
         {
             half4 bloom = UpsampleBox(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, UnityStereoAdjustedTexelSize(_MainTex_TexelSize).xy, _SampleScale);
-            return Combine(bloom, i.texcoordStereo);
+			return Combine(bloom, i.texcoordStereo);
         }
 
         // ----------------------------------------------------------------------------------------

--- a/PostProcessing/Shaders/Builtins/Bloom.shader
+++ b/PostProcessing/Shaders/Builtins/Bloom.shader
@@ -10,8 +10,8 @@ Shader "Hidden/PostProcessing/Bloom"
         TEXTURE2D_SAMPLER2D(_BloomTex, sampler_BloomTex);
         TEXTURE2D_SAMPLER2D(_AutoExposureTex, sampler_AutoExposureTex);
 
-        float4 _MainTex_TexelSize;
-        float4 _SampleScale;
+		float4 _MainTex_TexelSize;
+        float  _SampleScale;
         float4 _ColorIntensity;
         float4 _Threshold; // x: threshold value (linear), y: threshold - knee, z: knee * 2, w: 0.25 / knee
         float4 _Params; // x: clamp, yzw: unused
@@ -30,13 +30,13 @@ Shader "Hidden/PostProcessing/Bloom"
 
         half4 FragPrefilter13(VaryingsDefault i) : SV_Target
         {
-            half4 color = DownsampleBox13Tap(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, _MainTex_TexelSize.xy);
+            half4 color = DownsampleBox13Tap(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, UnityStereoAdjustedTexelSize(_MainTex_TexelSize).xy);
             return Prefilter(SafeHDR(color), i.texcoord);
         }
 
         half4 FragPrefilter4(VaryingsDefault i) : SV_Target
         {
-            half4 color = DownsampleBox4Tap(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, _MainTex_TexelSize.xy);
+            half4 color = DownsampleBox4Tap(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, UnityStereoAdjustedTexelSize(_MainTex_TexelSize).xy);
             return Prefilter(SafeHDR(color), i.texcoord);
         }
 
@@ -45,13 +45,13 @@ Shader "Hidden/PostProcessing/Bloom"
 
         half4 FragDownsample13(VaryingsDefault i) : SV_Target
         {
-            half4 color = DownsampleBox13Tap(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, _MainTex_TexelSize.xy);
+            half4 color = DownsampleBox13Tap(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, UnityStereoAdjustedTexelSize(_MainTex_TexelSize).xy);
             return color;
         }
 
         half4 FragDownsample4(VaryingsDefault i) : SV_Target
         {
-            half4 color = DownsampleBox4Tap(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, _MainTex_TexelSize.xy);
+            half4 color = DownsampleBox4Tap(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, UnityStereoAdjustedTexelSize(_MainTex_TexelSize).xy);
             return color;
         }
 
@@ -66,13 +66,13 @@ Shader "Hidden/PostProcessing/Bloom"
 
         half4 FragUpsampleTent(VaryingsDefault i) : SV_Target
         {
-            half4 bloom = UpsampleTent(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, _MainTex_TexelSize.xy, _SampleScale);
+            half4 bloom = UpsampleTent(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, UnityStereoAdjustedTexelSize(_MainTex_TexelSize).xy, _SampleScale);
             return Combine(bloom, i.texcoordStereo);
         }
 
         half4 FragUpsampleBox(VaryingsDefault i) : SV_Target
         {
-            half4 bloom = UpsampleBox(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, _MainTex_TexelSize.xy, _SampleScale);
+            half4 bloom = UpsampleBox(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, UnityStereoAdjustedTexelSize(_MainTex_TexelSize).xy, _SampleScale);
             return Combine(bloom, i.texcoordStereo);
         }
 
@@ -87,13 +87,13 @@ Shader "Hidden/PostProcessing/Bloom"
 
         half4 FragDebugOverlayTent(VaryingsDefault i) : SV_Target
         {
-            half4 bloom = UpsampleTent(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, _MainTex_TexelSize.xy, _SampleScale);
+            half4 bloom = UpsampleTent(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, UnityStereoAdjustedTexelSize(_MainTex_TexelSize).xy, _SampleScale);
             return half4(bloom.rgb * _ColorIntensity.w * _ColorIntensity.rgb, 1.0);
         }
 
         half4 FragDebugOverlayBox(VaryingsDefault i) : SV_Target
         {
-            half4 bloom = UpsampleBox(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, _MainTex_TexelSize.xy, _SampleScale);
+            half4 bloom = UpsampleBox(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, UnityStereoAdjustedTexelSize(_MainTex_TexelSize).xy, _SampleScale);
             return half4(bloom.rgb * _ColorIntensity.w * _ColorIntensity.rgb, 1.0);
         }
 

--- a/PostProcessing/Shaders/Builtins/Bloom.shader
+++ b/PostProcessing/Shaders/Builtins/Bloom.shader
@@ -10,7 +10,7 @@ Shader "Hidden/PostProcessing/Bloom"
         TEXTURE2D_SAMPLER2D(_BloomTex, sampler_BloomTex);
         TEXTURE2D_SAMPLER2D(_AutoExposureTex, sampler_AutoExposureTex);
 
-		float4 _MainTex_TexelSize;
+        float4 _MainTex_TexelSize;
         float  _SampleScale;
         float4 _ColorIntensity;
         float4 _Threshold; // x: threshold value (linear), y: threshold - knee, z: knee * 2, w: 0.25 / knee
@@ -31,7 +31,7 @@ Shader "Hidden/PostProcessing/Bloom"
         half4 FragPrefilter13(VaryingsDefault i) : SV_Target
         {
             half4 color = DownsampleBox13Tap(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, UnityStereoAdjustedTexelSize(_MainTex_TexelSize).xy);
-			return Prefilter(SafeHDR(color), i.texcoord);
+            return Prefilter(SafeHDR(color), i.texcoord);
         }
 
         half4 FragPrefilter4(VaryingsDefault i) : SV_Target
@@ -46,7 +46,7 @@ Shader "Hidden/PostProcessing/Bloom"
         half4 FragDownsample13(VaryingsDefault i) : SV_Target
         {
             half4 color = DownsampleBox13Tap(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, UnityStereoAdjustedTexelSize(_MainTex_TexelSize).xy);
-			return color;
+            return color;
         }
 
         half4 FragDownsample4(VaryingsDefault i) : SV_Target
@@ -67,13 +67,13 @@ Shader "Hidden/PostProcessing/Bloom"
         half4 FragUpsampleTent(VaryingsDefault i) : SV_Target
         {
             half4 bloom = UpsampleTent(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, UnityStereoAdjustedTexelSize(_MainTex_TexelSize).xy, _SampleScale);
-			return Combine(bloom, i.texcoordStereo);
+            return Combine(bloom, i.texcoordStereo);
         }
 
         half4 FragUpsampleBox(VaryingsDefault i) : SV_Target
         {
             half4 bloom = UpsampleBox(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, UnityStereoAdjustedTexelSize(_MainTex_TexelSize).xy, _SampleScale);
-			return Combine(bloom, i.texcoordStereo);
+            return Combine(bloom, i.texcoordStereo);
         }
 
         // ----------------------------------------------------------------------------------------

--- a/PostProcessing/Shaders/Builtins/Bloom.shader
+++ b/PostProcessing/Shaders/Builtins/Bloom.shader
@@ -11,7 +11,7 @@ Shader "Hidden/PostProcessing/Bloom"
         TEXTURE2D_SAMPLER2D(_AutoExposureTex, sampler_AutoExposureTex);
 
         float4 _MainTex_TexelSize;
-        float _SampleScale;
+        float4 _SampleScale;
         float4 _ColorIntensity;
         float4 _Threshold; // x: threshold value (linear), y: threshold - knee, z: knee * 2, w: 0.25 / knee
         float4 _Params; // x: clamp, yzw: unused

--- a/PostProcessing/Shaders/Sampling.hlsl
+++ b/PostProcessing/Shaders/Sampling.hlsl
@@ -54,7 +54,7 @@ half4 DownsampleBox4Tap(TEXTURE2D_ARGS(tex, samplerTex), float2 uv, float2 texel
 }
 
 // 9-tap bilinear upsampler (tent filter)
-half4 UpsampleTent(TEXTURE2D_ARGS(tex, samplerTex), float2 uv, float2 texelSize, float sampleScale)
+half4 UpsampleTent(TEXTURE2D_ARGS(tex, samplerTex), float2 uv, float2 texelSize, float4 sampleScale)
 {
     float4 d = texelSize.xyxy * float4(1.0, 1.0, -1.0, 0.0) * sampleScale;
 
@@ -75,7 +75,7 @@ half4 UpsampleTent(TEXTURE2D_ARGS(tex, samplerTex), float2 uv, float2 texelSize,
 }
 
 // Standard box filtering
-half4 UpsampleBox(TEXTURE2D_ARGS(tex, samplerTex), float2 uv, float2 texelSize, float sampleScale)
+half4 UpsampleBox(TEXTURE2D_ARGS(tex, samplerTex), float2 uv, float2 texelSize, float4 sampleScale)
 {
     float4 d = texelSize.xyxy * float4(-1.0, -1.0, 1.0, 1.0) * (sampleScale * 0.5);
 

--- a/PostProcessing/Shaders/Sampling.hlsl
+++ b/PostProcessing/Shaders/Sampling.hlsl
@@ -36,7 +36,7 @@ half4 DownsampleBox13Tap(TEXTURE2D_ARGS(tex, samplerTex), float2 uv, float2 texe
     o += (F + G + L + K) * div.y;
     o += (G + H + M + L) * div.y;
 
-    return o;
+	return o;
 }
 
 // Standard box filtering
@@ -71,7 +71,7 @@ half4 UpsampleTent(TEXTURE2D_ARGS(tex, samplerTex), float2 uv, float2 texelSize,
     s += SAMPLE_TEXTURE2D(tex, samplerTex, UnityStereoTransformScreenSpaceTex(uv + d.wy)) * 2.0;
     s += SAMPLE_TEXTURE2D(tex, samplerTex, UnityStereoTransformScreenSpaceTex(uv + d.xy));
 
-    return s * (1.0 / 16.0);
+	return s * (1.0 / 16.0);
 }
 
 // Standard box filtering

--- a/PostProcessing/Shaders/Sampling.hlsl
+++ b/PostProcessing/Shaders/Sampling.hlsl
@@ -36,7 +36,7 @@ half4 DownsampleBox13Tap(TEXTURE2D_ARGS(tex, samplerTex), float2 uv, float2 texe
     o += (F + G + L + K) * div.y;
     o += (G + H + M + L) * div.y;
 
-	return o;
+    return o;
 }
 
 // Standard box filtering
@@ -71,7 +71,7 @@ half4 UpsampleTent(TEXTURE2D_ARGS(tex, samplerTex), float2 uv, float2 texelSize,
     s += SAMPLE_TEXTURE2D(tex, samplerTex, UnityStereoTransformScreenSpaceTex(uv + d.wy)) * 2.0;
     s += SAMPLE_TEXTURE2D(tex, samplerTex, UnityStereoTransformScreenSpaceTex(uv + d.xy));
 
-	return s * (1.0 / 16.0);
+    return s * (1.0 / 16.0);
 }
 
 // Standard box filtering

--- a/PostProcessing/Shaders/xRLib.hlsl
+++ b/PostProcessing/Shaders/xRLib.hlsl
@@ -65,6 +65,13 @@ float2 UnityStereoClamp(float2 uv)
     scaleOffset.xy *= _RenderViewportScaleFactor;
     return UnityStereoClampScaleOffset(uv, scaleOffset);
 }
+
+float4 UnityStereoAdjustedTexelSize(float4 texelSize) // Should take in _MainTex_TexelSize
+{
+	texelSize.x = texelSize.x * 2.0; // texelSize.x = 1/w. For a double-wide texture, the true resolution is given by 2/w. 
+	texelSize.z = texelSize.z * 0.5; // texelSize.z = w. For a double-wide texture, the true size of the eye texture is given by w/2. 
+	return texelSize;
+}
 #else
 float2 TransformStereoScreenSpaceTex(float2 uv, float w)
 {
@@ -80,6 +87,11 @@ float2 UnityStereoClamp(float2 uv)
 {
     float4 scaleOffset = float4(_RenderViewportScaleFactor, _RenderViewportScaleFactor, 0.f, 0.f);
     return UnityStereoClampScaleOffset(uv, scaleOffset);
+}
+
+float4 UnityStereoAdjustedTexelSize(float4 texelSize)
+{
+	return texelSize;
 }
 #endif
 


### PR DESCRIPTION
After fighting with this for a while, @kdaugaard recommended I make sure that the sampling offsets were calculated correctly for a double-wide texture. Sure enough, I found that the sample offset was calculated based on the full 2x texture width, when it should be calculated from the per-eye screen width. Thanks Kaspar!

Also, it turns out the bloom offset issue described in https://github.com/Unity-Technologies/PostProcessing/issues/556 was due to the uneven split of resolution per-eye in downsampled bloom textures. After adding some code in Bloom.cs to ensure that downsampled textures have even widths when rendering single-pass double-wide, the offset vanished:
![image](https://user-images.githubusercontent.com/3450690/46166278-ae726800-c247-11e8-8985-e27d920201c8.png)

This changeset addresses the following bloom-related issues:
https://github.com/Unity-Technologies/PostProcessing/issues/559
https://github.com/Unity-Technologies/PostProcessing/issues/556

There is also an issue where there is sampling bleed across the boundary between the eyes, but I think we're fine to leave it since it would be covered up by the regions of the HMD that are not visible anyways. 