### PR TITLE
Fixed grain shader compilation errors on some mobile GPUs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.16-preview]
+
+### Fixed
+- Grain shader compilation errors on some mobile GPUs.
+
 ## [2.0.15-preview]
 
 ### Fixed

--- a/PostProcessing/Runtime/Effects/Grain.cs
+++ b/PostProcessing/Runtime/Effects/Grain.cs
@@ -71,6 +71,7 @@ namespace UnityEngine.Rendering.PostProcessing
             var sheet = context.propertySheets.Get(context.resources.shaders.grainBaker);
             sheet.properties.Clear();
             sheet.properties.SetFloat(ShaderIDs.Phase, time % 10f);
+            sheet.properties.SetVector(ShaderIDs.GrainNoiseParameters, new Vector3(12.9898f, 78.233f, 43758.5453f));
 
             context.command.BeginSample("GrainLookup");
             context.command.BlitFullscreenTriangle(BuiltinRenderTextureType.None, m_GrainLookupRT, sheet, settings.colored.value ? 1 : 0);

--- a/PostProcessing/Runtime/Utils/ShaderIDs.cs
+++ b/PostProcessing/Runtime/Utils/ShaderIDs.cs
@@ -132,6 +132,7 @@ namespace UnityEngine.Rendering.PostProcessing
         internal static readonly int Grain_Params2                   = Shader.PropertyToID("_Grain_Params2");
         internal static readonly int GrainTex                        = Shader.PropertyToID("_GrainTex");
         internal static readonly int Phase                           = Shader.PropertyToID("_Phase");
+        internal static readonly int GrainNoiseParameters            = Shader.PropertyToID("_NoiseParameters");
 
         internal static readonly int LumaInAlpha                     = Shader.PropertyToID("_LumaInAlpha");
 

--- a/PostProcessing/Shaders/Builtins/GrainBaker.shader
+++ b/PostProcessing/Shaders/Builtins/GrainBaker.shader
@@ -7,6 +7,7 @@ Shader "Hidden/PostProcessing/GrainBaker"
         #include "../StdLib.hlsl"
 
         float _Phase;
+        float3 _NoiseParameters;
 
         // Implementation based on Timothy Lottes' "Large Grain"
         // Reference code: https://www.shadertoy.com/view/4sSXDW
@@ -14,7 +15,7 @@ Shader "Hidden/PostProcessing/GrainBaker"
         float Noise(float2 n, float x)
         {
             n += x;
-            return frac(sin(dot(n.xy, float2(12.9898, 78.233))) * 43758.5453);
+            return frac(sin(dot(n.xy, _NoiseParameters.xy)) * _NoiseParameters.z);
         }
 
         float Step1(float2 uv, float n)


### PR DESCRIPTION
Fixed grain shader compilation errors on some mobile GPUs.
(Internal compiler error: Too many fragment shader constants)