### PR TITLE
XR interface and single-pass instancing

### DIFF
--- a/PostProcessing/PostProcessResources.asset
+++ b/PostProcessing/PostProcessResources.asset
@@ -92,6 +92,8 @@ MonoBehaviour:
     bloom: {fileID: 4800000, guid: c1e1d3119c6fd4646aea0b4b74cacc1a, type: 3}
     copy: {fileID: 4800000, guid: cdbdb71de5f9c454b980f6d0e87f0afb, type: 3}
     copyStd: {fileID: 4800000, guid: 4bf4cff0d0bac3d43894e2e8839feb40, type: 3}
+    copyStdFromTexArray: {fileID: 4800000, guid: 02d2da9bc88d25c4d878c1ed4e0b3854,
+      type: 3}
     discardAlpha: {fileID: 4800000, guid: 5ab0816423f0dfe45841cab3b05ec9ef, type: 3}
     depthOfField: {fileID: 4800000, guid: 0ef78d24e85a44f4da9d5b5eaa00e50b, type: 3}
     finalPass: {fileID: 4800000, guid: f75014305794b3948a3c6d5ccd550e05, type: 3}

--- a/PostProcessing/Runtime/Effects/Bloom.cs
+++ b/PostProcessing/Runtime/Effects/Bloom.cs
@@ -111,7 +111,7 @@ namespace UnityEngine.Rendering.PostProcessing
             // fillrate limited platforms
             int tw = Mathf.FloorToInt(context.screenWidth / (2f - rw));
             int th = Mathf.FloorToInt(context.screenHeight / (2f - rh));
-            bool singlePassDoubleWide = (context.stereoActive && (context.camera.stereoTargetEye == StereoTargetEyeMask.Both));
+            bool singlePassDoubleWide = (context.stereoActive && (context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePass) && (context.camera.stereoTargetEye == StereoTargetEyeMask.Both));
             int tw_stereo = singlePassDoubleWide ? tw * 2 : tw; 
 
             // Determine the iteration count

--- a/PostProcessing/Runtime/PostProcessLayer.cs
+++ b/PostProcessing/Runtime/PostProcessLayer.cs
@@ -663,12 +663,9 @@ namespace UnityEngine.Rendering.PostProcessing
 
             // Do a NaN killing pass if needed
             int lastTarget = -1;
-            int eyes = 1;
-            if (context.stereoActive && context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePassInstanced)
-                eyes = 2;
             RenderTargetIdentifier cameraTexture = context.source;
             
-            for (int eye = 0; eye < eyes; eye++)
+            for (int eye = 0; eye < context.numberOfEyes; eye++)
             {
                 bool preparedStereoSource = false;
 
@@ -687,7 +684,7 @@ namespace UnityEngine.Rendering.PostProcessing
                     m_NaNKilled = true;
                 }
 
-                if (!preparedStereoSource && eyes > 1)
+                if (!preparedStereoSource && context.numberOfEyes > 1)
                 {
                     lastTarget = m_TargetPool.Get();
                     context.GetScreenSpaceTemporaryRT(cmd, lastTarget, 0, context.sourceFormat);

--- a/PostProcessing/Runtime/PostProcessRenderContext.cs
+++ b/PostProcessing/Runtime/PostProcessRenderContext.cs
@@ -52,6 +52,11 @@ namespace UnityEngine.Rendering.PostProcessing
                         stereoRenderingMode = StereoRenderingMode.SinglePassInstanced;
                     else
                         stereoRenderingMode = StereoRenderingMode.SinglePass;
+
+                    if (stereoRenderingMode == StereoRenderingMode.SinglePassInstanced)
+                        numberOfEyes = 2;
+                    else
+                        numberOfEyes = 1; //currently, double-wide still issues two drawcalls
                 }
                 else
 #endif
@@ -66,6 +71,7 @@ namespace UnityEngine.Rendering.PostProcessing
                     screenWidth = width;
                     screenHeight = height;
                     stereoActive = false;
+                    numberOfEyes = 1;
                 }
             }
         }
@@ -115,6 +121,8 @@ namespace UnityEngine.Rendering.PostProcessing
 
         // Current active rendering eye (for XR)
         public int xrActiveEye { get; private set; }
+
+        public int numberOfEyes { get; private set; }
 
         public enum StereoRenderingMode
         {

--- a/PostProcessing/Runtime/PostProcessRenderContext.cs
+++ b/PostProcessing/Runtime/PostProcessRenderContext.cs
@@ -47,6 +47,11 @@ namespace UnityEngine.Rendering.PostProcessing
                     screenWidth = XRSettings.eyeTextureWidth;
                     screenHeight = XRSettings.eyeTextureHeight;
                     stereoActive = true;
+                    
+                    if (xrDesc.dimension == TextureDimension.Tex2DArray)
+                        stereoRenderingMode = StereoRenderingMode.SinglePassInstanced;
+                    else
+                        stereoRenderingMode = StereoRenderingMode.SinglePass;
                 }
                 else
 #endif
@@ -110,6 +115,16 @@ namespace UnityEngine.Rendering.PostProcessing
 
         // Current active rendering eye (for XR)
         public int xrActiveEye { get; private set; }
+
+        public enum StereoRenderingMode
+        {
+            MultiPass = 0,
+            SinglePass,
+            SinglePassInstanced,
+            SinglePassMultiview
+        }
+
+        public StereoRenderingMode stereoRenderingMode { get; private set; }
 
         // Pixel dimensions of logical screen size
         public int screenWidth { get; private set; }
@@ -238,6 +253,10 @@ namespace UnityEngine.Rendering.PostProcessing
             if (heightOverride > 0)
                 desc.height = heightOverride;
 
+            //intermediates in VR are unchanged
+            if (stereoActive && desc.dimension == Rendering.TextureDimension.Tex2DArray)
+               desc.dimension = Rendering.TextureDimension.Tex2D;
+          
             cmd.GetTemporaryRT(nameID, desc, filter);
 #else
             int actualWidth = width;

--- a/PostProcessing/Runtime/PostProcessRenderContext.cs
+++ b/PostProcessing/Runtime/PostProcessRenderContext.cs
@@ -47,12 +47,12 @@ namespace UnityEngine.Rendering.PostProcessing
                     screenWidth = XRSettings.eyeTextureWidth;
                     screenHeight = XRSettings.eyeTextureHeight;
                     stereoActive = true;
-                    
+                    stereoRenderingMode = StereoRenderingMode.SinglePass;
+
+#if UNITY_STANDALONE || UNITY_EDITOR
                     if (xrDesc.dimension == TextureDimension.Tex2DArray)
                         stereoRenderingMode = StereoRenderingMode.SinglePassInstanced;
-                    else
-                        stereoRenderingMode = StereoRenderingMode.SinglePass;
-
+#endif
                     if (stereoRenderingMode == StereoRenderingMode.SinglePassInstanced)
                         numberOfEyes = 2;
                     else

--- a/PostProcessing/Runtime/PostProcessResources.cs
+++ b/PostProcessing/Runtime/PostProcessResources.cs
@@ -15,6 +15,7 @@ namespace UnityEngine.Rendering.PostProcessing
             public Shader bloom;
             public Shader copy;
             public Shader copyStd;
+            public Shader copyStdFromTexArray;
             public Shader discardAlpha;
             public Shader depthOfField;
             public Shader finalPass;

--- a/PostProcessing/Runtime/Utils/RuntimeUtilities.cs
+++ b/PostProcessing/Runtime/Utils/RuntimeUtilities.cs
@@ -230,6 +230,25 @@ namespace UnityEngine.Rendering.PostProcessing
             }
         }
 
+        static Material s_CopyFromTexArrayMaterial;
+        public static Material copyFromTexArrayMaterial
+        {
+            get
+            {
+                if (s_CopyFromTexArrayMaterial != null)
+                    return s_CopyFromTexArrayMaterial;
+
+                var shader = Shader.Find("Hidden/PostProcessing/CopyStdFromTexArray");
+                s_CopyFromTexArrayMaterial = new Material(shader)
+                {
+                    name = "PostProcess - CopyFromTexArray",
+                    hideFlags = HideFlags.HideAndDontSave
+                };
+
+                return s_CopyFromTexArrayMaterial;
+            }
+        }
+
         static PropertySheet s_CopySheet;
         public static PropertySheet copySheet
         {
@@ -239,6 +258,18 @@ namespace UnityEngine.Rendering.PostProcessing
                     s_CopySheet = new PropertySheet(copyMaterial);
 
                 return s_CopySheet;
+            }
+        }
+
+        static PropertySheet s_CopyFromTexArraySheet;
+        public static PropertySheet copyFromTexArraySheet
+        {
+            get
+            {
+                if (s_CopyFromTexArraySheet == null)
+                    s_CopyFromTexArraySheet = new PropertySheet(copyFromTexArrayMaterial);
+
+                return s_CopyFromTexArraySheet;
             }
         }
 
@@ -305,6 +336,44 @@ namespace UnityEngine.Rendering.PostProcessing
             #endif
         }
 
+        public static void BlitFullscreenTriangleFromTexArray(this CommandBuffer cmd, RenderTargetIdentifier source, RenderTargetIdentifier destination, PropertySheet propertySheet, int pass, bool clear = false, int depthSlice = -1)
+        {
+            cmd.SetGlobalTexture(ShaderIDs.MainTex, source);
+            cmd.SetGlobalInt(ShaderIDs.DepthSlice, depthSlice);
+            cmd.SetRenderTargetWithLoadStoreAction(destination, RenderBufferLoadAction.DontCare, RenderBufferStoreAction.Store);
+
+            if (clear)
+                cmd.ClearRenderTarget(true, true, Color.clear);
+
+            cmd.DrawMesh(fullscreenTriangle, Matrix4x4.identity, propertySheet.material, 0, pass, propertySheet.properties);
+        }
+
+        public static void BlitFullscreenTriangleToTexArray(this CommandBuffer cmd, RenderTargetIdentifier source, RenderTargetIdentifier destination, PropertySheet propertySheet, int pass, bool clear = false, int depthSlice = -1)
+        {
+            cmd.SetGlobalTexture(ShaderIDs.MainTex, source);
+            cmd.SetGlobalInt(ShaderIDs.DepthSlice, depthSlice);
+            //cmd.SetRenderTargetWithLoadStoreAction(destination, RenderBufferLoadAction.DontCare, RenderBufferStoreAction.Store);
+            cmd.SetRenderTarget(destination, 0, CubemapFace.Unknown, -1);
+
+            if (clear)
+                cmd.ClearRenderTarget(true, true, Color.clear);
+
+            cmd.DrawMesh(fullscreenTriangle, Matrix4x4.identity, propertySheet.material, 0, pass, propertySheet.properties);
+        }
+
+        public static void BlitFullscreenTriangleToTexArray(this CommandBuffer cmd, RenderTargetIdentifier source, RenderTargetIdentifier destination, PropertySheet propertySheet, int pass, bool clear = false)
+        {
+
+            cmd.SetGlobalTexture(ShaderIDs.MainTex, source);
+            //SetRenderTarget(Rendering.RenderTargetIdentifier color, Rendering.RenderTargetIdentifier depth, 
+            //int mipLevel, CubemapFace cubemapFace, int depthSlice);
+            cmd.SetRenderTarget(destination, 0, 0, CubemapFace.Unknown, -1);
+
+            if (clear)
+                cmd.ClearRenderTarget(true, true, Color.clear);
+
+            cmd.DrawMesh(fullscreenTriangle, Matrix4x4.identity, propertySheet.material, 0, pass, propertySheet.properties);
+        }
         public static void BlitFullscreenTriangle(this CommandBuffer cmd, RenderTargetIdentifier source, RenderTargetIdentifier destination, RenderTargetIdentifier depth, PropertySheet propertySheet, int pass, bool clear = false)
         {
             cmd.SetGlobalTexture(ShaderIDs.MainTex, source);

--- a/PostProcessing/Runtime/Utils/RuntimeUtilities.cs
+++ b/PostProcessing/Runtime/Utils/RuntimeUtilities.cs
@@ -352,7 +352,6 @@ namespace UnityEngine.Rendering.PostProcessing
         {
             cmd.SetGlobalTexture(ShaderIDs.MainTex, source);
             cmd.SetGlobalInt(ShaderIDs.DepthSlice, depthSlice);
-            //cmd.SetRenderTargetWithLoadStoreAction(destination, RenderBufferLoadAction.DontCare, RenderBufferStoreAction.Store);
             cmd.SetRenderTarget(destination, 0, CubemapFace.Unknown, -1);
 
             if (clear)
@@ -361,19 +360,6 @@ namespace UnityEngine.Rendering.PostProcessing
             cmd.DrawMesh(fullscreenTriangle, Matrix4x4.identity, propertySheet.material, 0, pass, propertySheet.properties);
         }
 
-        public static void BlitFullscreenTriangleToTexArray(this CommandBuffer cmd, RenderTargetIdentifier source, RenderTargetIdentifier destination, PropertySheet propertySheet, int pass, bool clear = false)
-        {
-
-            cmd.SetGlobalTexture(ShaderIDs.MainTex, source);
-            //SetRenderTarget(Rendering.RenderTargetIdentifier color, Rendering.RenderTargetIdentifier depth, 
-            //int mipLevel, CubemapFace cubemapFace, int depthSlice);
-            cmd.SetRenderTarget(destination, 0, 0, CubemapFace.Unknown, -1);
-
-            if (clear)
-                cmd.ClearRenderTarget(true, true, Color.clear);
-
-            cmd.DrawMesh(fullscreenTriangle, Matrix4x4.identity, propertySheet.material, 0, pass, propertySheet.properties);
-        }
         public static void BlitFullscreenTriangle(this CommandBuffer cmd, RenderTargetIdentifier source, RenderTargetIdentifier destination, RenderTargetIdentifier depth, PropertySheet propertySheet, int pass, bool clear = false)
         {
             cmd.SetGlobalTexture(ShaderIDs.MainTex, source);

--- a/PostProcessing/Runtime/Utils/ShaderIDs.cs
+++ b/PostProcessing/Runtime/Utils/ShaderIDs.cs
@@ -151,5 +151,6 @@ namespace UnityEngine.Rendering.PostProcessing
         internal static readonly int RenderViewportScaleFactor       = Shader.PropertyToID("_RenderViewportScaleFactor");
 
         internal static readonly int UVTransform                     = Shader.PropertyToID("_UVTransform");
+        internal static readonly int DepthSlice                      = Shader.PropertyToID("_DepthSlice");
     }
 }

--- a/PostProcessing/Shaders/Builtins/CopyStdFromTexArray.shader
+++ b/PostProcessing/Shaders/Builtins/CopyStdFromTexArray.shader
@@ -1,6 +1,7 @@
 Shader "Hidden/PostProcessing/CopyStdFromTexArray"
 {
-    //Blit from texture array slice
+    //Blit from texture array slice. Similar to CopyStd but with texture array as source
+    // and sampling from texture array. Having separate shader is cleaner than multiple #if in the code.
 
     Properties
     {
@@ -79,6 +80,7 @@ Shader "Hidden/PostProcessing/CopyStdFromTexArray"
     {
         Cull Off ZWrite Off ZTest Always
 
+        // 0 - Copy
         Pass
         {
             CGPROGRAM
@@ -89,6 +91,7 @@ Shader "Hidden/PostProcessing/CopyStdFromTexArray"
             ENDCG
         }
 
+        // 0 - Copy + NaN killer
         Pass
         {
             CGPROGRAM

--- a/PostProcessing/Shaders/Builtins/CopyStdFromTexArray.shader
+++ b/PostProcessing/Shaders/Builtins/CopyStdFromTexArray.shader
@@ -1,0 +1,102 @@
+Shader "Hidden/PostProcessing/CopyStdFromTexArray"
+{
+
+    Properties
+    {
+        _MainTex ("", 2DArray) = "white" {}
+    }
+
+    CGINCLUDE
+
+        struct Attributes
+        {
+            float3 vertex : POSITION;
+        };
+
+        struct Varyings
+        {
+            float4 vertex : SV_POSITION;
+            float3 texcoord : TEXCOORD0;
+        };
+
+		Texture2DArray _MainTex;
+		SamplerState sampler_MainTex;
+		int _DepthSlice;
+
+		float2 TransformTriangleVertexToUV(float2 vertex)
+		{
+			float2 uv = (vertex + 1.0) * 0.5;
+			return uv;
+		}
+
+        Varyings Vert(Attributes v)
+        {
+            Varyings o;
+			o.vertex = float4(v.vertex.xy, 0.0, 1.0);
+            o.texcoord.xy = TransformTriangleVertexToUV(v.vertex.xy);
+
+            #if UNITY_UV_STARTS_AT_TOP
+            o.texcoord.xy = o.texcoord.xy * float2(1.0, -1.0) + float2(0.0, 1.0);
+            #endif
+            o.texcoord.z = _DepthSlice;
+
+            return o;
+        }
+
+        float4 Frag(Varyings i) : SV_Target
+        {
+			float4 color = _MainTex.Sample(sampler_MainTex, i.texcoord);
+            return color;
+        }
+
+        bool IsNan(float x)
+        {
+            return (x < 0.0 || x > 0.0 || x == 0.0) ? false : true;
+        }
+
+        bool AnyIsNan(float4 x)
+        {
+            return IsNan(x.x) || IsNan(x.y) || IsNan(x.z) || IsNan(x.w);
+        }
+
+        float4 FragKillNaN(Varyings i) : SV_Target
+        {
+			float4 color = _MainTex.Sample(sampler_MainTex, i.texcoord);
+
+            if (AnyIsNan(color))
+            {
+                color = (0.0).xxxx;
+            }
+
+            return color;
+        }
+
+    ENDCG
+
+    SubShader
+    {
+        Cull Off ZWrite Off ZTest Always
+
+        // 0 - Copy
+        Pass
+        {
+            CGPROGRAM
+
+                #pragma vertex Vert
+                #pragma fragment Frag
+
+            ENDCG
+        }
+
+        // 1 - Copy + NaN killer
+        Pass
+        {
+            CGPROGRAM
+
+                #pragma vertex Vert
+                #pragma fragment FragKillNaN
+
+            ENDCG
+        }
+    }
+}

--- a/PostProcessing/Shaders/Builtins/CopyStdFromTexArray.shader
+++ b/PostProcessing/Shaders/Builtins/CopyStdFromTexArray.shader
@@ -1,5 +1,6 @@
 Shader "Hidden/PostProcessing/CopyStdFromTexArray"
 {
+    //Blit from texture array slice
 
     Properties
     {
@@ -7,6 +8,7 @@ Shader "Hidden/PostProcessing/CopyStdFromTexArray"
     }
 
     CGINCLUDE
+        #pragma target 3.5
 
         struct Attributes
         {
@@ -77,7 +79,6 @@ Shader "Hidden/PostProcessing/CopyStdFromTexArray"
     {
         Cull Off ZWrite Off ZTest Always
 
-        // 0 - Copy
         Pass
         {
             CGPROGRAM
@@ -88,7 +89,6 @@ Shader "Hidden/PostProcessing/CopyStdFromTexArray"
             ENDCG
         }
 
-        // 1 - Copy + NaN killer
         Pass
         {
             CGPROGRAM

--- a/PostProcessing/Shaders/Builtins/CopyStdFromTexArray.shader
+++ b/PostProcessing/Shaders/Builtins/CopyStdFromTexArray.shader
@@ -1,7 +1,7 @@
 Shader "Hidden/PostProcessing/CopyStdFromTexArray"
 {
     //Blit from texture array slice. Similar to CopyStd but with texture array as source
-    // and sampling from texture array. Having separate shader is cleaner than multiple #if in the code.
+    //and sampling from texture array. Having separate shader is cleaner than multiple #if in the code.
 
     Properties
     {
@@ -22,20 +22,20 @@ Shader "Hidden/PostProcessing/CopyStdFromTexArray"
             float3 texcoord : TEXCOORD0;
         };
 
-		Texture2DArray _MainTex;
-		SamplerState sampler_MainTex;
-		int _DepthSlice;
+        Texture2DArray _MainTex;
+        SamplerState sampler_MainTex;
+        int _DepthSlice;
 
-		float2 TransformTriangleVertexToUV(float2 vertex)
-		{
-			float2 uv = (vertex + 1.0) * 0.5;
-			return uv;
-		}
+        float2 TransformTriangleVertexToUV(float2 vertex)
+        {
+            float2 uv = (vertex + 1.0) * 0.5;
+            return uv;
+        }
 
         Varyings Vert(Attributes v)
         {
             Varyings o;
-			o.vertex = float4(v.vertex.xy, 0.0, 1.0);
+            o.vertex = float4(v.vertex.xy, 0.0, 1.0);
             o.texcoord.xy = TransformTriangleVertexToUV(v.vertex.xy);
 
             #if UNITY_UV_STARTS_AT_TOP
@@ -48,7 +48,7 @@ Shader "Hidden/PostProcessing/CopyStdFromTexArray"
 
         float4 Frag(Varyings i) : SV_Target
         {
-			float4 color = _MainTex.Sample(sampler_MainTex, i.texcoord);
+            float4 color = _MainTex.Sample(sampler_MainTex, i.texcoord);
             return color;
         }
 
@@ -64,7 +64,7 @@ Shader "Hidden/PostProcessing/CopyStdFromTexArray"
 
         float4 FragKillNaN(Varyings i) : SV_Target
         {
-			float4 color = _MainTex.Sample(sampler_MainTex, i.texcoord);
+            float4 color = _MainTex.Sample(sampler_MainTex, i.texcoord);
 
             if (AnyIsNan(color))
             {

--- a/PostProcessing/Shaders/Builtins/CopyStdFromTexArray.shader.meta
+++ b/PostProcessing/Shaders/Builtins/CopyStdFromTexArray.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 02d2da9bc88d25c4d878c1ed4e0b3854
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/PostProcessing/Shaders/Builtins/FinalPass.shader
+++ b/PostProcessing/Shaders/Builtins/FinalPass.shader
@@ -4,6 +4,7 @@ Shader "Hidden/PostProcessing/FinalPass"
 
         #pragma multi_compile __ FXAA FXAA_LOW
         #pragma multi_compile __ FXAA_KEEP_ALPHA
+        #pragma multi_compile __ STEREO_INSTANCING_ENABLED
         #include "../StdLib.hlsl"
         #include "../Colors.hlsl"
         #include "Dithering.hlsl"

--- a/PostProcessing/Shaders/Builtins/Uber.shader
+++ b/PostProcessing/Shaders/Builtins/Uber.shader
@@ -11,6 +11,8 @@ Shader "Hidden/PostProcessing/Uber"
         #pragma multi_compile __ VIGNETTE
         #pragma multi_compile __ GRAIN
         #pragma multi_compile __ FINALPASS
+        #pragma multi_compile __ STEREO_INSTANCING_ENABLED
+
 
         #include "../StdLib.hlsl"
         #include "../Colors.hlsl"

--- a/PostProcessing/Shaders/StdLib.hlsl
+++ b/PostProcessing/Shaders/StdLib.hlsl
@@ -270,7 +270,14 @@ struct VaryingsDefault
     float4 vertex : SV_POSITION;
     float2 texcoord : TEXCOORD0;
     float2 texcoordStereo : TEXCOORD1;
+#if STEREO_INSTANCING_ENABLED
+    uint stereoTargetEyeIndex : SV_RenderTargetArrayIndex;
+#endif
 };
+
+#if STEREO_INSTANCING_ENABLED
+int _DepthSlice;
+#endif
 
 VaryingsDefault VertDefault(AttributesDefault v)
 {
@@ -295,6 +302,9 @@ VaryingsDefault VertUVTransform(AttributesDefault v)
     o.vertex = float4(v.vertex.xy, 0.0, 1.0);
     o.texcoord = TransformTriangleVertexToUV(v.vertex.xy) * _UVTransform.xy + _UVTransform.zw;
     o.texcoordStereo = TransformStereoScreenSpaceTex(o.texcoord, 1.0);
+#if STEREO_INSTANCING_ENABLED
+    o.stereoTargetEyeIndex = _DepthSlice;
+#endif
     return o;
 }
 


### PR DESCRIPTION
Implemented XR interface and single-pass instancing for postprocessing. 
Design doc:
https://docs.google.com/document/d/1hANbhKCRIJs6ww7XoAIXbX3ArdAs7OBOTfZL1MqgtPI

Changes:
-For single-pass stereo instancing, XR interface provides the correct camera texture slice as source buffer for postprocessing. Added shader for sampling from texture array and BlitFromTextureArray call.
-For final pass, render the postprocess results to the correct eye texture slice. Added BlitToTextureArray.
-Added stereo instancing support in uber shader and finalpass shader. 
-Effects tested to work with XR interface and single-pass instancing: grain, bloom, FXAA, SMAA, color grading. 
XR interface will support single-pass double-wide next.

Testing:
Tested on Oculus Rift with LWRP and HDRP, in Standalone Player and Editor, with single-pass instancing and double-wide.
