### PR TITLE
Disable warning for unused fields

### DIFF
--- a/PostProcessing/Runtime/PostProcessLayer.cs
+++ b/PostProcessing/Runtime/PostProcessLayer.cs
@@ -48,9 +48,11 @@ namespace UnityEngine.Rendering.PostProcessing
         [SerializeField]
         PostProcessResources m_Resources;
 
+#pragma warning disable 169
         // UI states
         [SerializeField] bool m_ShowToolkit;
         [SerializeField] bool m_ShowCustomSorter;
+#pragma warning enable 169
 
         // Will stop applying post-processing effects just before color grading is applied
         // Currently used to export to exr without color grading

--- a/PostProcessing/Runtime/PostProcessLayer.cs
+++ b/PostProcessing/Runtime/PostProcessLayer.cs
@@ -52,7 +52,7 @@ namespace UnityEngine.Rendering.PostProcessing
         // UI states
         [SerializeField] bool m_ShowToolkit;
         [SerializeField] bool m_ShowCustomSorter;
-#pragma warning enable 169
+#pragma warning restore 169
 
         // Will stop applying post-processing effects just before color grading is applied
         // Currently used to export to exr without color grading


### PR DESCRIPTION
Two fields ShowToolkit and ShowCustomSorter are currently unused and cause warnings in projects that use them. Issue #690