### PR TITLE
Update shader include path that was causing build errors on Switch

### DIFF
--- a/PostProcessing/Shaders/Builtins/ScreenSpaceReflections.shader
+++ b/PostProcessing/Shaders/Builtins/ScreenSpaceReflections.shader
@@ -36,7 +36,7 @@ Shader "Hidden/PostProcessing/ScreenSpaceReflections"
             return o;
         }
 
-        #include "ScreenSpaceReflections.hlsl"
+        #include "Packages/com.unity.postprocessing/PostProcessing/Shaders/Builtins/ScreenSpaceReflections.hlsl"
 
     ENDCG
 


### PR DESCRIPTION
Update shader include path that was causing errors when trying to build https://github.com/Verasl/BoatAttack/commit/5f8123fe on Switch
