### PR TITLE
XR interface and single-pass double-wide support

### DIFF
--- a/PostProcessing/PostProcessResources.asset
+++ b/PostProcessing/PostProcessResources.asset
@@ -94,6 +94,8 @@ MonoBehaviour:
     copyStd: {fileID: 4800000, guid: 4bf4cff0d0bac3d43894e2e8839feb40, type: 3}
     copyStdFromTexArray: {fileID: 4800000, guid: 02d2da9bc88d25c4d878c1ed4e0b3854,
       type: 3}
+    copyStdFromDoubleWide: {fileID: 4800000, guid: e8ce9961912f3214586fe8709b9012c1,
+      type: 3}
     discardAlpha: {fileID: 4800000, guid: 5ab0816423f0dfe45841cab3b05ec9ef, type: 3}
     depthOfField: {fileID: 4800000, guid: 0ef78d24e85a44f4da9d5b5eaa00e50b, type: 3}
     finalPass: {fileID: 4800000, guid: f75014305794b3948a3c6d5ccd550e05, type: 3}

--- a/PostProcessing/Runtime/PostProcessLayer.cs
+++ b/PostProcessing/Runtime/PostProcessLayer.cs
@@ -734,7 +734,15 @@ namespace UnityEngine.Rendering.PostProcessing
             // Do a NaN killing pass if needed
             int lastTarget = -1;
             RenderTargetIdentifier cameraTexture = context.source;
-            
+
+#if UNITY_2019_1_OR_NEWER && XR_POSTPROCESSING_INTERFACE
+            if (context.stereoActive && context.numberOfEyes > 1 && context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePass)
+            {
+                cmd.SetSinglePassStereo(SinglePassStereoMode.None);
+                cmd.DisableShaderKeyword("UNITY_SINGLE_PASS_STEREO");
+            }
+#endif
+
             for (int eye = 0; eye < context.numberOfEyes; eye++)
             {
                 bool preparedStereoSource = false;
@@ -743,10 +751,18 @@ namespace UnityEngine.Rendering.PostProcessing
                 {
                     lastTarget = m_TargetPool.Get();
                     context.GetScreenSpaceTemporaryRT(cmd, lastTarget, 0, context.sourceFormat);
-                    if (context.stereoActive && context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePassInstanced)
+                    if (context.stereoActive && context.numberOfEyes > 1)
                     {
-                        cmd.BlitFullscreenTriangleFromTexArray(context.source, lastTarget, RuntimeUtilities.copyFromTexArraySheet, 1, false, eye);
-                        preparedStereoSource = true;
+                        if (context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePassInstanced)
+                        {
+                            cmd.BlitFullscreenTriangleFromTexArray(context.source, lastTarget, RuntimeUtilities.copyFromTexArraySheet, 1, false, eye);
+                            preparedStereoSource = true;
+                        }
+                        else if (context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePass)
+                        {
+                            cmd.BlitFullscreenTriangleFromDoubleWide(context.source, lastTarget, RuntimeUtilities.copyStdFromDoubleWideMaterial, 1, eye);
+                            preparedStereoSource = true;
+                        }
                     }
                     else
                         cmd.BlitFullscreenTriangle(context.source, lastTarget, RuntimeUtilities.copySheet, 1);
@@ -758,10 +774,18 @@ namespace UnityEngine.Rendering.PostProcessing
                 {
                     lastTarget = m_TargetPool.Get();
                     context.GetScreenSpaceTemporaryRT(cmd, lastTarget, 0, context.sourceFormat);
-                    if (context.stereoActive && context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePassInstanced)
+                    if (context.stereoActive)
                     {
-                        cmd.BlitFullscreenTriangleFromTexArray(context.source, lastTarget, RuntimeUtilities.copyFromTexArraySheet, 1, false, eye);
-                        preparedStereoSource = true;
+                        if (context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePassInstanced)
+                        {
+                            cmd.BlitFullscreenTriangleFromTexArray(context.source, lastTarget, RuntimeUtilities.copyFromTexArraySheet, 1, false, eye);
+                            preparedStereoSource = true;
+                        }
+                        else if (context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePass)
+                        {
+                            cmd.BlitFullscreenTriangleFromDoubleWide(context.source, lastTarget, RuntimeUtilities.copyStdFromDoubleWideMaterial, stopNaNPropagation ? 1 : 0, eye);
+                            preparedStereoSource = true;
+                        }
                     }
                     context.source = lastTarget;
                 }
@@ -821,6 +845,15 @@ namespace UnityEngine.Rendering.PostProcessing
                 if (context.stereoActive)
                     context.source = cameraTexture;
             }
+
+#if UNITY_2019_1_OR_NEWER && XR_POSTPROCESSING_INTERFACE
+            if (context.stereoActive && context.numberOfEyes > 1 && context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePass)
+            {
+                cmd.SetSinglePassStereo(SinglePassStereoMode.SideBySide);
+                cmd.EnableShaderKeyword("UNITY_SINGLE_PASS_STEREO");
+            }
+#endif
+
             // Render debug monitors & overlay if requested
             debugLayer.RenderSpecialOverlays(context);
             debugLayer.RenderMonitors(context);
@@ -993,6 +1026,10 @@ namespace UnityEngine.Rendering.PostProcessing
                 uberSheet.properties.SetInt(ShaderIDs.DepthSlice, eye);
                 cmd.BlitFullscreenTriangleToTexArray(context.source, context.destination, uberSheet, 0, false, eye);
             }
+            else if (isFinalPass && context.stereoActive && context.numberOfEyes > 1 && context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePass)
+            {
+                cmd.BlitFullscreenTriangleToDoubleWide(context.source, context.destination, uberSheet, 0, eye);
+            }
             else
                 cmd.BlitFullscreenTriangle(context.source, context.destination, uberSheet, 0);
                
@@ -1025,6 +1062,10 @@ namespace UnityEngine.Rendering.PostProcessing
                 {
                     sheet.properties.SetInt(ShaderIDs.DepthSlice, eye);
                     cmd.BlitFullscreenTriangleToTexArray(context.source, context.destination, sheet, 0, false, eye);
+                }
+                else if (context.stereoActive && context.numberOfEyes > 1 && context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePass)
+                {
+                    cmd.BlitFullscreenTriangleToDoubleWide(context.source, context.destination, sheet, 0, eye);
                 }
                 else
                     cmd.BlitFullscreenTriangle(context.source, context.destination, sheet, 0);
@@ -1068,6 +1109,10 @@ namespace UnityEngine.Rendering.PostProcessing
                 {
                     uberSheet.properties.SetInt(ShaderIDs.DepthSlice, eye);
                     cmd.BlitFullscreenTriangleToTexArray(context.source, context.destination, uberSheet, 0, false, eye);
+                }
+                else if (context.stereoActive && context.numberOfEyes > 1 && context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePass)
+                {
+                    cmd.BlitFullscreenTriangleToDoubleWide(context.source, context.destination, uberSheet, 0, eye);
                 }
                 else
                     cmd.BlitFullscreenTriangle(context.source, context.destination, uberSheet, 0);

--- a/PostProcessing/Runtime/PostProcessRenderContext.cs
+++ b/PostProcessing/Runtime/PostProcessRenderContext.cs
@@ -28,6 +28,30 @@ namespace UnityEngine.Rendering.PostProcessing
                 {
 #if UNITY_2017_2_OR_NEWER
                     var xrDesc = XRSettings.eyeTextureDesc;
+                    stereoRenderingMode = StereoRenderingMode.SinglePass;
+
+#if UNITY_STANDALONE || UNITY_EDITOR
+                    if (xrDesc.dimension == TextureDimension.Tex2DArray)
+                        stereoRenderingMode = StereoRenderingMode.SinglePassInstanced;
+#endif
+                    if (stereoRenderingMode == StereoRenderingMode.SinglePassInstanced)
+                        numberOfEyes = 2;
+
+#if UNITY_2019_1_OR_NEWER && XR_POSTPROCESSING_INTERFACE
+                    if (stereoRenderingMode == StereoRenderingMode.SinglePass)
+                    {
+                        numberOfEyes = 2;
+                        xrDesc.width /= 2;
+                        xrDesc.vrUsage = VRTextureUsage.None;
+                    }
+#else
+                    //before 2019.1 double-wide still issues two drawcalls
+                    if (stereoRenderingMode == StereoRenderingMode.SinglePass)
+                    {
+                        numberOfEyes = 1;
+                    }
+#endif
+
                     width = xrDesc.width;
                     height = xrDesc.height;
                     m_sourceDescriptor = xrDesc;
@@ -46,17 +70,13 @@ namespace UnityEngine.Rendering.PostProcessing
 
                     screenWidth = XRSettings.eyeTextureWidth;
                     screenHeight = XRSettings.eyeTextureHeight;
-                    stereoActive = true;
-                    stereoRenderingMode = StereoRenderingMode.SinglePass;
 
-#if UNITY_STANDALONE || UNITY_EDITOR
-                    if (xrDesc.dimension == TextureDimension.Tex2DArray)
-                        stereoRenderingMode = StereoRenderingMode.SinglePassInstanced;
+#if UNITY_2019_1_OR_NEWER && XR_POSTPROCESSING_INTERFACE
+                    if (stereoRenderingMode == StereoRenderingMode.SinglePass)
+                        screenWidth /= 2;
 #endif
-                    if (stereoRenderingMode == StereoRenderingMode.SinglePassInstanced)
-                        numberOfEyes = 2;
-                    else
-                        numberOfEyes = 1; //currently, double-wide still issues two drawcalls
+                    stereoActive = true;
+
                 }
                 else
 #endif

--- a/PostProcessing/Runtime/PostProcessResources.cs
+++ b/PostProcessing/Runtime/PostProcessResources.cs
@@ -16,6 +16,7 @@ namespace UnityEngine.Rendering.PostProcessing
             public Shader copy;
             public Shader copyStd;
             public Shader copyStdFromTexArray;
+            public Shader copyStdFromDoubleWide;
             public Shader discardAlpha;
             public Shader depthOfField;
             public Shader finalPass;

--- a/PostProcessing/Runtime/Utils/RuntimeUtilities.cs
+++ b/PostProcessing/Runtime/Utils/RuntimeUtilities.cs
@@ -211,6 +211,25 @@ namespace UnityEngine.Rendering.PostProcessing
             }
         }
 
+        static Material s_CopyStdFromDoubleWideMaterial;
+        public static Material copyStdFromDoubleWideMaterial
+        {
+            get
+            {
+                if (s_CopyStdFromDoubleWideMaterial != null)
+                    return s_CopyStdFromDoubleWideMaterial;
+
+                var shader = Shader.Find("Hidden/PostProcessing/CopyStdFromDoubleWide");
+                s_CopyStdFromDoubleWideMaterial = new Material(shader)
+                {
+                    name = "PostProcess - CopyStdFromDoubleWide",
+                    hideFlags = HideFlags.HideAndDontSave
+                };
+
+                return s_CopyStdFromDoubleWideMaterial;
+            }
+        }
+
         static Material s_CopyMaterial;
         public static Material copyMaterial
         {
@@ -358,6 +377,27 @@ namespace UnityEngine.Rendering.PostProcessing
                 cmd.ClearRenderTarget(true, true, Color.clear);
 
             cmd.DrawMesh(fullscreenTriangle, Matrix4x4.identity, propertySheet.material, 0, pass, propertySheet.properties);
+        }
+
+        public static void BlitFullscreenTriangleFromDoubleWide(this CommandBuffer cmd, RenderTargetIdentifier source, RenderTargetIdentifier destination, Material material, int pass, int eye)
+        {
+            Vector4 uvScaleOffset = new Vector4(0.5f, 1.0f, 0, 0);
+
+            if (eye == 1)
+                uvScaleOffset.z = 0.5f;
+            cmd.SetGlobalVector(ShaderIDs.UVScaleOffset, uvScaleOffset);
+            cmd.BuiltinBlit(source, destination, material, pass);
+        }
+
+        public static void BlitFullscreenTriangleToDoubleWide(this CommandBuffer cmd, RenderTargetIdentifier source, RenderTargetIdentifier destination, PropertySheet propertySheet, int pass, int eye)
+        {
+            Vector4 posScaleOffset = new Vector4(0.5f, 1.0f, -0.5f, 0);
+
+            if (eye == 1)
+                posScaleOffset.z = 0.5f;
+            propertySheet.EnableKeyword("STEREO_DOUBLEWIDE_TARGET");
+            propertySheet.properties.SetVector(ShaderIDs.PosScaleOffset, posScaleOffset);
+            cmd.BlitFullscreenTriangle(source, destination, propertySheet, 0);
         }
 
         public static void BlitFullscreenTriangle(this CommandBuffer cmd, RenderTargetIdentifier source, RenderTargetIdentifier destination, RenderTargetIdentifier depth, PropertySheet propertySheet, int pass, bool clear = false)

--- a/PostProcessing/Runtime/Utils/ShaderIDs.cs
+++ b/PostProcessing/Runtime/Utils/ShaderIDs.cs
@@ -153,5 +153,7 @@ namespace UnityEngine.Rendering.PostProcessing
 
         internal static readonly int UVTransform                     = Shader.PropertyToID("_UVTransform");
         internal static readonly int DepthSlice                      = Shader.PropertyToID("_DepthSlice");
+        internal static readonly int UVScaleOffset                   = Shader.PropertyToID("_UVScaleOffset");
+        internal static readonly int PosScaleOffset                  = Shader.PropertyToID("_PosScaleOffset");
     }
 }

--- a/PostProcessing/Shaders/Builtins/CopyStdFromDoubleWide.shader
+++ b/PostProcessing/Shaders/Builtins/CopyStdFromDoubleWide.shader
@@ -1,0 +1,101 @@
+Shader "Hidden/PostProcessing/CopyStdFromDoubleWide"
+{
+    //Blit from single-pass double-wide texture. Similar to CopyStd but with stereo texture as source
+    //and samples from double-wide. Having separate shader is cleaner than multiple #if in the code.
+
+    Properties
+    {
+        _MainTex ("", 2D) = "white" {}
+    }
+
+    CGINCLUDE
+
+        struct Attributes
+        {
+            float4 vertex : POSITION;
+            float2 texcoord : TEXCOORD0;
+        };
+
+        struct Varyings
+        {
+            float4 vertex : SV_POSITION;
+            float2 texcoord : TEXCOORD0;
+        };
+
+        sampler2D _MainTex;
+        float4 _UVScaleOffset;
+
+        Varyings Vert(Attributes v)
+        {
+            Varyings o;
+            o.vertex = float4(v.vertex.xy * 2.0 - 1.0, 0.0, 1.0);
+            o.texcoord = v.texcoord;
+
+            #if UNITY_UV_STARTS_AT_TOP
+            o.texcoord = o.texcoord * float2(1.0, -1.0) + float2(0.0, 1.0);
+            #endif
+
+            o.texcoord = o.texcoord * _UVScaleOffset.xy + _UVScaleOffset.zw;
+
+            return o;
+        }
+
+        float4 Frag(Varyings i) : SV_Target
+        {
+            float4 color = tex2D(_MainTex, i.texcoord);
+            return color;
+        }
+
+        //>>> We don't want to include StdLib.hlsl in this file so let's copy/paste what we need
+        bool IsNan(float x)
+        {
+            return (x < 0.0 || x > 0.0 || x == 0.0) ? false : true;
+        }
+
+        bool AnyIsNan(float4 x)
+        {
+            return IsNan(x.x) || IsNan(x.y) || IsNan(x.z) || IsNan(x.w);
+        }
+        //<<<
+
+        float4 FragKillNaN(Varyings i) : SV_Target
+        {
+            float4 color = tex2D(_MainTex, i.texcoord);
+
+            if (AnyIsNan(color))
+            {
+                color = (0.0).xxxx;
+            }
+
+            return color;
+        }
+
+    ENDCG
+
+    SubShader
+    {
+        Cull Off ZWrite Off ZTest Always
+
+        // 0 - Copy
+        Pass
+        {
+            CGPROGRAM
+
+                #pragma vertex Vert
+                #pragma fragment Frag
+
+            ENDCG
+        }
+
+        // 1 - Copy + NaN killer
+        Pass
+        {
+            CGPROGRAM
+
+                #pragma vertex Vert
+                #pragma fragment FragKillNaN
+
+            ENDCG
+        }
+    }
+}

--- a/PostProcessing/Shaders/Builtins/CopyStdFromDoubleWide.shader.meta
+++ b/PostProcessing/Shaders/Builtins/CopyStdFromDoubleWide.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: e8ce9961912f3214586fe8709b9012c1
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/PostProcessing/Shaders/Builtins/FinalPass.shader
+++ b/PostProcessing/Shaders/Builtins/FinalPass.shader
@@ -5,6 +5,7 @@ Shader "Hidden/PostProcessing/FinalPass"
         #pragma multi_compile __ FXAA FXAA_LOW
         #pragma multi_compile __ FXAA_KEEP_ALPHA
         #pragma multi_compile __ STEREO_INSTANCING_ENABLED
+        #pragma multi_compile __ STEREO_DOUBLEWIDE_TARGET
         #include "../StdLib.hlsl"
         #include "../Colors.hlsl"
         #include "Dithering.hlsl"

--- a/PostProcessing/Shaders/Builtins/Uber.shader
+++ b/PostProcessing/Shaders/Builtins/Uber.shader
@@ -12,6 +12,7 @@ Shader "Hidden/PostProcessing/Uber"
         #pragma multi_compile __ GRAIN
         #pragma multi_compile __ FINALPASS
         #pragma multi_compile __ STEREO_INSTANCING_ENABLED
+        #pragma multi_compile __ STEREO_DOUBLEWIDE_TARGET
 
 
         #include "../StdLib.hlsl"

--- a/PostProcessing/Shaders/StdLib.hlsl
+++ b/PostProcessing/Shaders/StdLib.hlsl
@@ -296,10 +296,19 @@ VaryingsDefault VertDefault(AttributesDefault v)
 
 float4 _UVTransform; // xy: scale, wz: translate
 
+#if STEREO_DOUBLEWIDE_TARGET
+float4 _PosScaleOffset; // xy: scale, wz: offset
+#endif
+
 VaryingsDefault VertUVTransform(AttributesDefault v)
 {
     VaryingsDefault o;
+
+#if STEREO_DOUBLEWIDE_TARGET
+    o.vertex = float4(v.vertex.xy * _PosScaleOffset.xy + _PosScaleOffset.zw, 0.0, 1.0);
+#else
     o.vertex = float4(v.vertex.xy, 0.0, 1.0);
+#endif
     o.texcoord = TransformTriangleVertexToUV(v.vertex.xy) * _UVTransform.xy + _UVTransform.zw;
     o.texcoordStereo = TransformStereoScreenSpaceTex(o.texcoord, 1.0);
 #if STEREO_INSTANCING_ENABLED


### PR DESCRIPTION
This is part 2 of implementing XR interface for postprocessing. Added support for single-pass double-wide stereo mode for postprocessing. 

Design doc:
https://docs.google.com/document/d/1hANbhKCRIJs6ww7XoAIXbX3ArdAs7OBOTfZL1MqgtPI

Changes:
-For single-pass double-wide stereo mode, XR interface provides the correct half of double-wide camera texture as source buffer for postprocessing. Added shader for sampling from double-wide texture and BlitFromDoubleWide function.
-For final pass, render the postprocess results to the correct half of double-wide eye texture. Added BlitToDoubleWide function.
-Added stereo double-wide target output support in uber shader and finalpass shader.
-Effects tested to work with XR interface and single-pass double-wide: grain, bloom, FXAA, SMAA, color grading.

Testing:
Tested on Oculus Rift with LWRP and HDRP, in Standalone Player and Editor, with single-pass double-wide and instancing