### PR TITLE
Fixed compatibility with 2017.x

### DIFF
--- a/PostProcessing/Editor/PostProcessLayerEditor.cs
+++ b/PostProcessing/Editor/PostProcessLayerEditor.cs
@@ -15,7 +15,9 @@ namespace UnityEditor.Rendering.PostProcessing
     public sealed class PostProcessLayerEditor : BaseEditor<PostProcessLayer>
     {
         SerializedProperty m_StopNaNPropagation;
+#pragma warning disable 414
         SerializedProperty m_DirectToCameraTarget;
+#pragma warning restore 414
         SerializedProperty m_VolumeTrigger;
         SerializedProperty m_VolumeLayer;
 

--- a/PostProcessing/Runtime/PostProcessLayer.cs
+++ b/PostProcessing/Runtime/PostProcessLayer.cs
@@ -990,7 +990,7 @@ namespace UnityEngine.Rendering.PostProcessing
 
             if (context.stereoActive && context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePassInstanced)
             {
-                uberSheet.properties.SetInt(ShaderIDs.DepthSlice, eye);
+                uberSheet.properties.SetFloat(ShaderIDs.DepthSlice, eye);
                 cmd.BlitFullscreenTriangleToTexArray(context.source, context.destination, uberSheet, 0, false, eye);
             }
             else if (isFinalPass)
@@ -1025,7 +1025,7 @@ namespace UnityEngine.Rendering.PostProcessing
 
                 if (context.stereoActive && context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePassInstanced)
                 {
-                    sheet.properties.SetInt(ShaderIDs.DepthSlice, eye);
+                    sheet.properties.SetFloat(ShaderIDs.DepthSlice, eye);
                     cmd.BlitFullscreenTriangleToTexArray(context.source, context.destination, sheet, 0, false, eye);
                 }
                 else
@@ -1068,7 +1068,7 @@ namespace UnityEngine.Rendering.PostProcessing
                 ApplyFlip(context, uberSheet.properties);
                 if (context.stereoActive && context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePassInstanced)
                 {
-                    uberSheet.properties.SetInt(ShaderIDs.DepthSlice, eye);
+                    uberSheet.properties.SetFloat(ShaderIDs.DepthSlice, eye);
                     cmd.BlitFullscreenTriangleToTexArray(context.source, context.destination, uberSheet, 0, false, eye);
                 }
                 else

--- a/PostProcessing/Runtime/Utils/RuntimeUtilities.cs
+++ b/PostProcessing/Runtime/Utils/RuntimeUtilities.cs
@@ -348,7 +348,7 @@ namespace UnityEngine.Rendering.PostProcessing
         public static void BlitFullscreenTriangleFromTexArray(this CommandBuffer cmd, RenderTargetIdentifier source, RenderTargetIdentifier destination, PropertySheet propertySheet, int pass, bool clear = false, int depthSlice = -1)
         {
             cmd.SetGlobalTexture(ShaderIDs.MainTex, source);
-            cmd.SetGlobalInt(ShaderIDs.DepthSlice, depthSlice);
+            cmd.SetGlobalFloat(ShaderIDs.DepthSlice, depthSlice);
             cmd.SetRenderTargetWithLoadStoreAction(destination, RenderBufferLoadAction.DontCare, RenderBufferStoreAction.Store);
 
             if (clear)
@@ -360,7 +360,7 @@ namespace UnityEngine.Rendering.PostProcessing
         public static void BlitFullscreenTriangleToTexArray(this CommandBuffer cmd, RenderTargetIdentifier source, RenderTargetIdentifier destination, PropertySheet propertySheet, int pass, bool clear = false, int depthSlice = -1)
         {
             cmd.SetGlobalTexture(ShaderIDs.MainTex, source);
-            cmd.SetGlobalInt(ShaderIDs.DepthSlice, depthSlice);
+            cmd.SetGlobalFloat(ShaderIDs.DepthSlice, depthSlice);
             cmd.SetRenderTarget(destination, 0, CubemapFace.Unknown, -1);
 
             if (clear)

--- a/PostProcessing/Shaders/Builtins/CopyStdFromTexArray.shader
+++ b/PostProcessing/Shaders/Builtins/CopyStdFromTexArray.shader
@@ -24,7 +24,7 @@ Shader "Hidden/PostProcessing/CopyStdFromTexArray"
 
         Texture2DArray _MainTex;
         SamplerState sampler_MainTex;
-        int _DepthSlice;
+        float _DepthSlice;
 
         float2 TransformTriangleVertexToUV(float2 vertex)
         {

--- a/PostProcessing/Shaders/StdLib.hlsl
+++ b/PostProcessing/Shaders/StdLib.hlsl
@@ -1,4 +1,4 @@
-﻿// Because this framework is supposed to work with the legacy render pipelines AND scriptable render
+// Because this framework is supposed to work with the legacy render pipelines AND scriptable render
 // pipelines we can't use Unity's shader libraries (some scriptable pipelines come with their own
 // shader lib). So here goes a minimal shader lib only used for post-processing to ensure good
 // compatibility with all pipelines.
@@ -276,7 +276,7 @@ struct VaryingsDefault
 };
 
 #if STEREO_INSTANCING_ENABLED
-int _DepthSlice;
+float _DepthSlice;
 #endif
 
 VaryingsDefault VertDefault(AttributesDefault v)
@@ -303,7 +303,7 @@ VaryingsDefault VertUVTransform(AttributesDefault v)
     o.texcoord = TransformTriangleVertexToUV(v.vertex.xy) * _UVTransform.xy + _UVTransform.zw;
     o.texcoordStereo = TransformStereoScreenSpaceTex(o.texcoord, 1.0);
 #if STEREO_INSTANCING_ENABLED
-    o.stereoTargetEyeIndex = _DepthSlice;
+    o.stereoTargetEyeIndex = (uint)_DepthSlice;
 #endif
     return o;
 }

--- a/PostProcessing/Tests/Runtime/PostProcessingRuntimeTests.cs
+++ b/PostProcessing/Tests/Runtime/PostProcessingRuntimeTests.cs
@@ -56,11 +56,13 @@ class PostProcessingTests : IPrebuildSetup
         var bloom = profile.AddSettings<Bloom>();
         Assert.IsNotNull(bloom);
 
-        var exists = profile.TryGetSettings(out Bloom outBloom);
+        Bloom outBloom;
+        var exists = profile.TryGetSettings(out outBloom);
         Assert.IsTrue(exists);
         Assert.IsNotNull(outBloom);
 
-        exists = profile.TryGetSettings(out ChromaticAberration outChroma);
+        ChromaticAberration outChroma;
+        exists = profile.TryGetSettings(out outChroma);
         Assert.IsFalse(exists);
         Assert.IsNull(outChroma);
 


### PR DESCRIPTION
`SetInt` and `SetGlobalInt` were introduced in 2018.1. Unfortunately using them breaks compatibility with previous versions of Unity and post-processing v2 needs to stay compatible with 2017.x.

I changed the int to a float, given that it's used as a depth slice it should be fine in this case but I don't have the necessary hardware to test on so I'll let you confirm that it indeed works. Feel free to ping me up on slack!