### PR TITLE
[XR] remove temporary define and enable XR Interface for double-wide stereo

### DIFF
--- a/PostProcessing/Runtime/PostProcessLayer.cs
+++ b/PostProcessing/Runtime/PostProcessLayer.cs
@@ -846,7 +846,7 @@ namespace UnityEngine.Rendering.PostProcessing
             int lastTarget = -1;
             RenderTargetIdentifier cameraTexture = context.source;
 
-#if UNITY_2019_1_OR_NEWER && XR_POSTPROCESSING_INTERFACE
+#if UNITY_2019_1_OR_NEWER
             if (context.stereoActive && context.numberOfEyes > 1 && context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePass)
             {
                 cmd.SetSinglePassStereo(SinglePassStereoMode.None);
@@ -957,7 +957,7 @@ namespace UnityEngine.Rendering.PostProcessing
                     context.source = cameraTexture;
             }
 
-#if UNITY_2019_1_OR_NEWER && XR_POSTPROCESSING_INTERFACE
+#if UNITY_2019_1_OR_NEWER
             if (context.stereoActive && context.numberOfEyes > 1 && context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePass)
             {
                 cmd.SetSinglePassStereo(SinglePassStereoMode.SideBySide);

--- a/PostProcessing/Runtime/PostProcessRenderContext.cs
+++ b/PostProcessing/Runtime/PostProcessRenderContext.cs
@@ -42,7 +42,7 @@ namespace UnityEngine.Rendering.PostProcessing
                     if (stereoRenderingMode == StereoRenderingMode.SinglePassInstanced)
                         numberOfEyes = 2;
 
-#if UNITY_2019_1_OR_NEWER && XR_POSTPROCESSING_INTERFACE
+#if UNITY_2019_1_OR_NEWER
                     if (stereoRenderingMode == StereoRenderingMode.SinglePass)
                     {
                         numberOfEyes = 2;
@@ -76,7 +76,7 @@ namespace UnityEngine.Rendering.PostProcessing
                     screenWidth = XRSettings.eyeTextureWidth;
                     screenHeight = XRSettings.eyeTextureHeight;
 
-#if UNITY_2019_1_OR_NEWER && XR_POSTPROCESSING_INTERFACE
+#if UNITY_2019_1_OR_NEWER
                     if (stereoRenderingMode == StereoRenderingMode.SinglePass)
                         screenWidth /= 2;
 #endif


### PR DESCRIPTION
Remove temporary define for XR_POSTPROCESSING_INTERFACE, which was there for QA to test with engine PR branch for SetSinglePassStereo. Since that PR for adding command buffer command SetSinglePassStereo() has landed in trunk, the define can be removed and XR interface will work by default.

Testing:
Tested on Oculus Rift with LWRP and HDRP, in Standalone Player and Editor, with single-pass double-wide and instancing