### PR TITLE
Fix for Switch compilation.

### DIFF
--- a/PostProcessing/Runtime/Utils/XRSettings.cs
+++ b/PostProcessing/Runtime/Utils/XRSettings.cs
@@ -1,5 +1,5 @@
 // Small shim for VRSettings/XRSettings on XboxOne, Switch and PS Vita
-#if ((UNITY_XBOXONE && !UNITY_2018_3_OR_NEWER) || UNITY_SWITCH || UNITY_PSP2) && !UNITY_EDITOR
+#if ((UNITY_XBOXONE || UNITY_SWITCH || UNITY_PSP2) && !UNITY_2018_3_OR_NEWER)  && !UNITY_EDITOR
 using System;
 
 #if UNITY_2017_2_OR_NEWER


### PR DESCRIPTION
This is a fix to get the Switch player to build.
This fix was advised by XR Team as XRSettings is now stubbed on all platforms.