### PR TITLE
Changed pragma warning disable to UNITY_EDITOR preprocessor directive…

### DIFF
--- a/PostProcessing/Runtime/PostProcessLayer.cs
+++ b/PostProcessing/Runtime/PostProcessLayer.cs
@@ -114,11 +114,11 @@ namespace UnityEngine.Rendering.PostProcessing
         [SerializeField]
         PostProcessResources m_Resources;
 
-#pragma warning disable 169
+#if UNITY_EDITOR
         // UI states
         [SerializeField] bool m_ShowToolkit;
         [SerializeField] bool m_ShowCustomSorter;
-#pragma warning restore 169
+#endif
 
         /// <summary>
         /// If <c>true</c>, it will stop applying post-processing effects just before color grading


### PR DESCRIPTION
…. This variables are only used in editor mode so it will prevent the compilation warning.

Our project is very sensitive to compilation warnings and we can't include the library as it is now