### PR TITLE
use SystemInfo.usesLoadStoreActions on 2019.3+ instead of Application…

### DIFF
--- a/PostProcessing/Runtime/PostProcessLayer.cs
+++ b/PostProcessing/Runtime/PostProcessLayer.cs
@@ -232,7 +232,7 @@ namespace UnityEngine.Rendering.PostProcessing
             m_Camera.AddCommandBuffer(CameraEvent.BeforeLighting, m_LegacyCmdBufferBeforeLighting);
             m_Camera.AddCommandBuffer(CameraEvent.BeforeImageEffectsOpaque, m_LegacyCmdBufferOpaque);
             m_Camera.AddCommandBuffer(CameraEvent.BeforeImageEffects, m_LegacyCmdBuffer);
-               
+
             // Internal context used if no SRP is set
             m_CurrentContext = new PostProcessRenderContext();
         }
@@ -397,7 +397,11 @@ namespace UnityEngine.Rendering.PostProcessing
             //   and use LoadAction.DontCare freely, which will ruin the RT if we are using viewport.
             // It should actually check for having tiled architecture but this is not exposed to script,
             // so we are checking for mobile as a good substitute
+#if UNITY_2019_3_OR_NEWER
+            if(SystemInfo.usesLoadStoreActions)
+#else
             if(Application.isMobilePlatform)
+#endif
             {
                 Rect r = m_Camera.rect;
                 if(Mathf.Abs(r.x) > 1e-6f || Mathf.Abs(r.y) > 1e-6f || Mathf.Abs(1.0f - r.width) > 1e-6f || Mathf.Abs(1.0f - r.height) > 1e-6f)
@@ -450,7 +454,7 @@ namespace UnityEngine.Rendering.PostProcessing
                 return true;
             if (RuntimeUtilities.scriptableRenderPipelineActive) // Should never be called from SRP
                 return true;
-              
+
             return false;
 #else
             return true;
@@ -561,7 +565,7 @@ namespace UnityEngine.Rendering.PostProcessing
                     cmd.BuiltinBlit(context.source, context.destination, RuntimeUtilities.copyStdMaterial, stopNaNPropagation ? 1 : 0);
                     UpdateSrcDstForOpaqueOnly(ref srcTarget, ref dstTarget, context, cameraTarget, opaqueOnlyEffects);
                 }
- 
+
                 if (isScreenSpaceReflectionsActive)
                 {
                     ssrRenderer.Render(context);
@@ -581,7 +585,7 @@ namespace UnityEngine.Rendering.PostProcessing
 
                 cmd.ReleaseTemporaryRT(srcTarget);
             }
-            
+
             // Post-transparency stack
             int tempRt = -1;
             bool forceNanKillPass = (!m_NaNKilled && stopNaNPropagation && RuntimeUtilities.isFloatingPointFormat(sourceFormat));
@@ -614,7 +618,7 @@ namespace UnityEngine.Rendering.PostProcessing
                     context.flip = true;
                     context.destination = Display.main.colorBuffer;
                 }
-            } 
+            }
 #endif
 
             context.command = m_LegacyCmdBuffer;
@@ -635,9 +639,9 @@ namespace UnityEngine.Rendering.PostProcessing
             {
 #if UNITY_2018_2_OR_NEWER
                 // TAA calls SetProjectionMatrix so if the camera projection mode was physical, it gets set to explicit. So we set it back to physical.
-                if (m_CurrentContext.physicalCamera)   
+                if (m_CurrentContext.physicalCamera)
                     m_Camera.usePhysicalProperties = true;
-                else 
+                else
 #endif
                     m_Camera.ResetProjectionMatrix();
 


### PR DESCRIPTION
….isMobilePlatform to determine if we should warn about using viewport with postprocessing