### PR TITLE
Adding support for dynamic resolution 

### DIFF
--- a/PostProcessing/Editor/PostProcessLayerEditor.cs
+++ b/PostProcessing/Editor/PostProcessLayerEditor.cs
@@ -162,6 +162,9 @@ namespace UnityEditor.Rendering.PostProcessing
                     if (RuntimeUtilities.isSinglePassStereoSelected)
                         EditorGUILayout.HelpBox("TAA requires Unity 2017.3+ for Single-pass stereo rendering support.", MessageType.Warning);
                     #endif
+                    var camera = m_Target.GetComponent<Camera>();
+                    if (camera.allowDynamicResolution)
+                        EditorGUILayout.HelpBox("TAA is not supported with Dynamic Resolution.", MessageType.Warning);
 
                     EditorGUILayout.PropertyField(m_TaaJitterSpread);
                     EditorGUILayout.PropertyField(m_TaaStationaryBlending);

--- a/PostProcessing/Editor/PostProcessLayerEditor.cs
+++ b/PostProcessing/Editor/PostProcessLayerEditor.cs
@@ -38,6 +38,10 @@ namespace UnityEditor.Rendering.PostProcessing
 
         Dictionary<PostProcessEvent, ReorderableList> m_CustomLists;
 
+        #if UNITY_2017_3_OR_NEWER
+        Camera m_TargetCameraComponent;
+        #endif
+
         static GUIContent[] s_AntialiasingMethodNames =
         {
             new GUIContent("No Anti-aliasing"),
@@ -75,6 +79,10 @@ namespace UnityEditor.Rendering.PostProcessing
 
             m_ShowToolkit = serializedObject.FindProperty("m_ShowToolkit");
             m_ShowCustomSorter = serializedObject.FindProperty("m_ShowCustomSorter");
+
+            #if UNITY_2017_3_OR_NEWER
+            m_TargetCameraComponent = m_Target.GetComponent<Camera>();
+            #endif
         }
 
         void OnDisable()
@@ -162,9 +170,10 @@ namespace UnityEditor.Rendering.PostProcessing
                     if (RuntimeUtilities.isSinglePassStereoSelected)
                         EditorGUILayout.HelpBox("TAA requires Unity 2017.3+ for Single-pass stereo rendering support.", MessageType.Warning);
                     #endif
-                    var camera = m_Target.GetComponent<Camera>();
-                    if (camera.allowDynamicResolution)
+                    #if UNITY_2017_3_OR_NEWER
+                    if (m_TargetCameraComponent != null && m_TargetCameraComponent.allowDynamicResolution)
                         EditorGUILayout.HelpBox("TAA is not supported with Dynamic Resolution.", MessageType.Warning);
+                    #endif
 
                     EditorGUILayout.PropertyField(m_TaaJitterSpread);
                     EditorGUILayout.PropertyField(m_TaaStationaryBlending);

--- a/PostProcessing/Runtime/Effects/MotionBlur.cs
+++ b/PostProcessing/Runtime/Effects/MotionBlur.cs
@@ -60,14 +60,20 @@ namespace UnityEngine.Rendering.PostProcessing
 
         private void CreateTemporaryRT(PostProcessRenderContext context, int nameID, int width, int height, RenderTextureFormat RTFormat)
         {
+            var cmd = context.command;
+#if UNITY_2017_2_OR_NEWER            
             var rtDesc = context.GetDescriptor(0, RTFormat, RenderTextureReadWrite.Linear);
             rtDesc.width = width;
             rtDesc.height = height;
-            var cmd = context.command;
 #if UNITY_2019_1_OR_NEWER
             cmd.GetTemporaryRT(nameID, rtDesc, FilterMode.Point);
-#else
+#elif UNITY_2017_3_OR_NEWER
             cmd.GetTemporaryRT(nameID, rtDesc.width, rtDesc.height, rtDesc.depthBufferBits, FilterMode.Point, rtDesc.colorFormat, RenderTextureReadWrite.Linear, rtDesc.msaaSamples, rtDesc.enableRandomWrite, rtDesc.memoryless, context.camera.allowDynamicResolution);
+#else            
+            cmd.GetTemporaryRT(nameID, rtDesc.width, rtDesc.height, rtDesc.depthBufferBits, FilterMode.Point, rtDesc.colorFormat, RenderTextureReadWrite.Linear, rtDesc.msaaSamples, rtDesc.enableRandomWrite, rtDesc.memoryless);
+#endif
+#else
+            cmd.GetTemporaryRT(nameID, width, height, 0, FilterMode.Point, RTFormat, RenderTextureReadWrite.Linear);
 #endif
         }
 

--- a/PostProcessing/Runtime/Effects/MotionBlur.cs
+++ b/PostProcessing/Runtime/Effects/MotionBlur.cs
@@ -60,9 +60,6 @@ namespace UnityEngine.Rendering.PostProcessing
 
         private void CreateTemporaryRT(PostProcessRenderContext context, int nameID, int width, int height, RenderTextureFormat RTFormat)
         {
-#if !UNITY_2019_1_OR_NEWER
-            bool useDynamicRes = context.camera.allowDynamicResolution;
-#endif
             var rtDesc = context.GetDescriptor(0, RTFormat, RenderTextureReadWrite.Linear);
             rtDesc.width = width;
             rtDesc.height = height;
@@ -70,7 +67,7 @@ namespace UnityEngine.Rendering.PostProcessing
 #if UNITY_2019_1_OR_NEWER
             cmd.GetTemporaryRT(nameID, rtDesc, FilterMode.Point);
 #else
-            cmd.GetTemporaryRT(nameID, rtDesc.width, rtDesc.height, rtDesc.depthBufferBits, FilterMode.Point, rtDesc.colorFormat, RenderTextureReadWrite.Linear, rtDesc.msaaSamples, rtDesc.enableRandomWrite, rtDesc.memoryless, useDynamicRes);
+            cmd.GetTemporaryRT(nameID, rtDesc.width, rtDesc.height, rtDesc.depthBufferBits, FilterMode.Point, rtDesc.colorFormat, RenderTextureReadWrite.Linear, rtDesc.msaaSamples, rtDesc.enableRandomWrite, rtDesc.memoryless, context.camera.allowDynamicResolution);
 #endif
         }
 

--- a/PostProcessing/Runtime/Effects/MotionBlur.cs
+++ b/PostProcessing/Runtime/Effects/MotionBlur.cs
@@ -92,27 +92,33 @@ namespace UnityEngine.Rendering.PostProcessing
             sheet.properties.SetFloat(ShaderIDs.RcpMaxBlurRadius, 1f / maxBlurPixels);
 
             int vbuffer = ShaderIDs.VelocityTex;
-            cmd.GetTemporaryRT(vbuffer, context.width, context.height, 0, FilterMode.Point,
-                packedRTFormat, RenderTextureReadWrite.Linear);
+            var rtDesc = context.GetDescriptor(0, packedRTFormat, RenderTextureReadWrite.Linear);
+            cmd.GetTemporaryRT(vbuffer, rtDesc, FilterMode.Point);
             cmd.BlitFullscreenTriangle(BuiltinRenderTextureType.None, vbuffer, sheet, (int)Pass.VelocitySetup);
 
             // Pass 2 - First TileMax filter (1/2 downsize)
             int tile2 = ShaderIDs.Tile2RT;
-            cmd.GetTemporaryRT(tile2, context.width / 2, context.height / 2, 0, FilterMode.Point,
-                vectorRTFormat, RenderTextureReadWrite.Linear);
+            rtDesc = context.GetDescriptor(0, vectorRTFormat, RenderTextureReadWrite.Linear);
+            rtDesc.width = context.width / 2;
+            rtDesc.height = context.height / 2;
+            cmd.GetTemporaryRT(tile2, rtDesc, FilterMode.Point);
             cmd.BlitFullscreenTriangle(vbuffer, tile2, sheet, (int)Pass.TileMax1);
 
             // Pass 3 - Second TileMax filter (1/2 downsize)
             int tile4 = ShaderIDs.Tile4RT;
-            cmd.GetTemporaryRT(tile4, context.width / 4, context.height / 4, 0, FilterMode.Point,
-                vectorRTFormat, RenderTextureReadWrite.Linear);
+            rtDesc = context.GetDescriptor(0, vectorRTFormat, RenderTextureReadWrite.Linear);
+            rtDesc.width = context.width / 4;
+            rtDesc.height = context.height / 4;
+            cmd.GetTemporaryRT(tile4, rtDesc, FilterMode.Point);
             cmd.BlitFullscreenTriangle(tile2, tile4, sheet, (int)Pass.TileMax2);
             cmd.ReleaseTemporaryRT(tile2);
 
             // Pass 4 - Third TileMax filter (1/2 downsize)
             int tile8 = ShaderIDs.Tile8RT;
-            cmd.GetTemporaryRT(tile8, context.width / 8, context.height / 8, 0, FilterMode.Point,
-                vectorRTFormat, RenderTextureReadWrite.Linear);
+            rtDesc = context.GetDescriptor(0, vectorRTFormat, RenderTextureReadWrite.Linear);
+            rtDesc.width = context.width / 8;
+            rtDesc.height = context.height / 8;
+            cmd.GetTemporaryRT(tile8, rtDesc, FilterMode.Point);
             cmd.BlitFullscreenTriangle(tile4, tile8, sheet, (int)Pass.TileMax2);
             cmd.ReleaseTemporaryRT(tile4);
 
@@ -122,17 +128,21 @@ namespace UnityEngine.Rendering.PostProcessing
             sheet.properties.SetFloat(ShaderIDs.TileMaxLoop, (int)(tileSize / 8f));
 
             int tile = ShaderIDs.TileVRT;
-            cmd.GetTemporaryRT(tile, context.width / tileSize, context.height / tileSize, 0,
-                FilterMode.Point, vectorRTFormat, RenderTextureReadWrite.Linear);
+            rtDesc = context.GetDescriptor(0, vectorRTFormat, RenderTextureReadWrite.Linear);
+            rtDesc.width = context.width / tileSize;
+            rtDesc.height = context.height / tileSize;
+            cmd.GetTemporaryRT(tile, rtDesc, FilterMode.Point);
             cmd.BlitFullscreenTriangle(tile8, tile, sheet, (int)Pass.TileMaxV);
             cmd.ReleaseTemporaryRT(tile8);
 
             // Pass 6 - NeighborMax filter
+            rtDesc = context.GetDescriptor(0, vectorRTFormat, RenderTextureReadWrite.Linear);
             int neighborMax = ShaderIDs.NeighborMaxTex;
             int neighborMaxWidth = context.width / tileSize;
             int neighborMaxHeight = context.height / tileSize;
-            cmd.GetTemporaryRT(neighborMax, neighborMaxWidth, neighborMaxHeight, 0,
-                FilterMode.Point, vectorRTFormat, RenderTextureReadWrite.Linear);
+            rtDesc.width = neighborMaxWidth;
+            rtDesc.height = neighborMaxHeight; 
+            cmd.GetTemporaryRT(neighborMax, rtDesc, FilterMode.Point);
             cmd.BlitFullscreenTriangle(tile, neighborMax, sheet, (int)Pass.NeighborMax);
             cmd.ReleaseTemporaryRT(tile);
 

--- a/PostProcessing/Runtime/Effects/MotionBlur.cs
+++ b/PostProcessing/Runtime/Effects/MotionBlur.cs
@@ -74,6 +74,9 @@ namespace UnityEngine.Rendering.PostProcessing
             var packedRTFormat = RenderTextureFormat.ARGB2101010.IsSupported()
                 ? RenderTextureFormat.ARGB2101010
                 : RenderTextureFormat.ARGB32;
+#if !UNITY_2019_1_OR_NEWER
+            bool useDynamicRes = context.camera.allowDynamicResolution;
+#endif
 
             var sheet = context.propertySheets.Get(context.resources.shaders.motionBlur);
             cmd.BeginSample("MotionBlur");
@@ -93,7 +96,11 @@ namespace UnityEngine.Rendering.PostProcessing
 
             int vbuffer = ShaderIDs.VelocityTex;
             var rtDesc = context.GetDescriptor(0, packedRTFormat, RenderTextureReadWrite.Linear);
+#if UNITY_2019_1_OR_NEWER
             cmd.GetTemporaryRT(vbuffer, rtDesc, FilterMode.Point);
+#else
+            cmd.GetTemporaryRT(vbuffer, rtDesc.width, rtDesc.height, rtDesc.depthBufferBits, FilterMode.Point, rtDesc.colorFormat, RenderTextureReadWrite.Linear, rtDesc.msaaSamples, rtDesc.enableRandomWrite, rtDesc.memoryless, useDynamicRes);
+#endif
             cmd.BlitFullscreenTriangle(BuiltinRenderTextureType.None, vbuffer, sheet, (int)Pass.VelocitySetup);
 
             // Pass 2 - First TileMax filter (1/2 downsize)
@@ -101,7 +108,11 @@ namespace UnityEngine.Rendering.PostProcessing
             rtDesc = context.GetDescriptor(0, vectorRTFormat, RenderTextureReadWrite.Linear);
             rtDesc.width = context.width / 2;
             rtDesc.height = context.height / 2;
+#if UNITY_2019_1_OR_NEWER
             cmd.GetTemporaryRT(tile2, rtDesc, FilterMode.Point);
+#else
+            cmd.GetTemporaryRT(tile2, rtDesc.width, rtDesc.height, rtDesc.depthBufferBits, FilterMode.Point, rtDesc.colorFormat, RenderTextureReadWrite.Linear, rtDesc.msaaSamples, rtDesc.enableRandomWrite, rtDesc.memoryless, useDynamicRes);
+#endif
             cmd.BlitFullscreenTriangle(vbuffer, tile2, sheet, (int)Pass.TileMax1);
 
             // Pass 3 - Second TileMax filter (1/2 downsize)
@@ -109,7 +120,11 @@ namespace UnityEngine.Rendering.PostProcessing
             rtDesc = context.GetDescriptor(0, vectorRTFormat, RenderTextureReadWrite.Linear);
             rtDesc.width = context.width / 4;
             rtDesc.height = context.height / 4;
+#if UNITY_2019_1_OR_NEWER
             cmd.GetTemporaryRT(tile4, rtDesc, FilterMode.Point);
+#else
+            cmd.GetTemporaryRT(tile4, rtDesc.width, rtDesc.height, rtDesc.depthBufferBits, FilterMode.Point, rtDesc.colorFormat, RenderTextureReadWrite.Linear, rtDesc.msaaSamples, rtDesc.enableRandomWrite, rtDesc.memoryless, useDynamicRes);
+#endif
             cmd.BlitFullscreenTriangle(tile2, tile4, sheet, (int)Pass.TileMax2);
             cmd.ReleaseTemporaryRT(tile2);
 
@@ -118,7 +133,11 @@ namespace UnityEngine.Rendering.PostProcessing
             rtDesc = context.GetDescriptor(0, vectorRTFormat, RenderTextureReadWrite.Linear);
             rtDesc.width = context.width / 8;
             rtDesc.height = context.height / 8;
+#if UNITY_2019_1_OR_NEWER
             cmd.GetTemporaryRT(tile8, rtDesc, FilterMode.Point);
+#else
+            cmd.GetTemporaryRT(tile8, rtDesc.width, rtDesc.height, rtDesc.depthBufferBits, FilterMode.Point, rtDesc.colorFormat, RenderTextureReadWrite.Linear, rtDesc.msaaSamples, rtDesc.enableRandomWrite, rtDesc.memoryless, useDynamicRes);
+#endif
             cmd.BlitFullscreenTriangle(tile4, tile8, sheet, (int)Pass.TileMax2);
             cmd.ReleaseTemporaryRT(tile4);
 
@@ -131,7 +150,11 @@ namespace UnityEngine.Rendering.PostProcessing
             rtDesc = context.GetDescriptor(0, vectorRTFormat, RenderTextureReadWrite.Linear);
             rtDesc.width = context.width / tileSize;
             rtDesc.height = context.height / tileSize;
+#if UNITY_2019_1_OR_NEWER
             cmd.GetTemporaryRT(tile, rtDesc, FilterMode.Point);
+#else
+            cmd.GetTemporaryRT(tile, rtDesc.width, rtDesc.height, rtDesc.depthBufferBits, FilterMode.Point, rtDesc.colorFormat, RenderTextureReadWrite.Linear, rtDesc.msaaSamples, rtDesc.enableRandomWrite, rtDesc.memoryless, useDynamicRes);
+#endif
             cmd.BlitFullscreenTriangle(tile8, tile, sheet, (int)Pass.TileMaxV);
             cmd.ReleaseTemporaryRT(tile8);
 
@@ -142,7 +165,11 @@ namespace UnityEngine.Rendering.PostProcessing
             int neighborMaxHeight = context.height / tileSize;
             rtDesc.width = neighborMaxWidth;
             rtDesc.height = neighborMaxHeight; 
+#if UNITY_2019_1_OR_NEWER
             cmd.GetTemporaryRT(neighborMax, rtDesc, FilterMode.Point);
+#else
+            cmd.GetTemporaryRT(neighborMax, rtDesc.width, rtDesc.height, rtDesc.depthBufferBits, FilterMode.Point, rtDesc.colorFormat, RenderTextureReadWrite.Linear, rtDesc.msaaSamples, rtDesc.enableRandomWrite, rtDesc.memoryless, useDynamicRes);
+#endif
             cmd.BlitFullscreenTriangle(tile, neighborMax, sheet, (int)Pass.NeighborMax);
             cmd.ReleaseTemporaryRT(tile);
 

--- a/PostProcessing/Runtime/Effects/MultiScaleVO.cs
+++ b/PostProcessing/Runtime/Effects/MultiScaleVO.cs
@@ -147,8 +147,13 @@ namespace UnityEngine.Rendering.PostProcessing
         public void GenerateAOMap(CommandBuffer cmd, Camera camera, RenderTargetIdentifier destination, RenderTargetIdentifier? depthMap, bool invert, bool isMSAA)
         {
             // Base size
+#if UNITY_2017_3_OR_NEWER
             m_ScaledWidths[0] = camera.scaledPixelWidth * (RuntimeUtilities.isSinglePassStereoEnabled ? 2 : 1);
             m_ScaledHeights[0] = camera.scaledPixelHeight;
+#else
+            m_ScaledWidths[0] = camera.pixelWidth * (RuntimeUtilities.isSinglePassStereoEnabled ? 2 : 1);
+            m_ScaledHeights[0] = camera.pixelHeight;       
+#endif
             
             // L1 -> L6 sizes
             for (int i = 1; i < 7; i++)
@@ -452,8 +457,11 @@ namespace UnityEngine.Rendering.PostProcessing
 
         void CheckAOTexture(PostProcessRenderContext context)
         {
-            if (m_AmbientOnlyAO == null || !m_AmbientOnlyAO.IsCreated() || m_AmbientOnlyAO.width != context.width || m_AmbientOnlyAO.height != context.height ||
-                m_AmbientOnlyAO.useDynamicScale != context.camera.allowDynamicResolution)
+            bool AOUpdateNeeded = m_AmbientOnlyAO == null || !m_AmbientOnlyAO.IsCreated() || m_AmbientOnlyAO.width != context.width || m_AmbientOnlyAO.height != context.height;
+#if UNITY_2017_3_OR_NEWER                
+            AOUpdateNeeded = AOUpdateNeeded || m_AmbientOnlyAO.useDynamicScale != context.camera.allowDynamicResolution;
+#endif                  
+            if (AOUpdateNeeded)
             {
                 RuntimeUtilities.Destroy(m_AmbientOnlyAO);
 
@@ -462,7 +470,9 @@ namespace UnityEngine.Rendering.PostProcessing
                     hideFlags = HideFlags.DontSave,
                     filterMode = FilterMode.Point,
                     enableRandomWrite = true,
+#if UNITY_2017_3_OR_NEWER
                     useDynamicScale = context.camera.allowDynamicResolution
+#endif
                 };
                 m_AmbientOnlyAO.Create();
             }

--- a/PostProcessing/Runtime/Effects/MultiScaleVO.cs
+++ b/PostProcessing/Runtime/Effects/MultiScaleVO.cs
@@ -40,8 +40,6 @@ namespace UnityEngine.Rendering.PostProcessing
         readonly float[] m_InvThicknessTable = new float[12];
         readonly float[] m_SampleWeightTable = new float[12];
 
-        readonly int[] m_Widths = new int[7];
-        readonly int[] m_Heights = new int[7];
         // Scaled dimensions used with dynamic resolution
         readonly int[] m_ScaledWidths = new int[7];
         readonly int[] m_ScaledHeights = new int[7];
@@ -148,9 +146,7 @@ namespace UnityEngine.Rendering.PostProcessing
 
         public void GenerateAOMap(CommandBuffer cmd, Camera camera, RenderTargetIdentifier destination, RenderTargetIdentifier? depthMap, bool invert, bool isMSAA)
         {
-            // Base size          
-            m_Widths[0] = camera.pixelWidth * (RuntimeUtilities.isSinglePassStereoEnabled ? 2 : 1);
-            m_Heights[0] = camera.pixelHeight;
+            // Base size
             m_ScaledWidths[0] = camera.scaledPixelWidth * (RuntimeUtilities.isSinglePassStereoEnabled ? 2 : 1);
             m_ScaledHeights[0] = camera.scaledPixelHeight;
             
@@ -158,8 +154,6 @@ namespace UnityEngine.Rendering.PostProcessing
             for (int i = 1; i < 7; i++)
             {
                 int div = 1 << i;
-                m_Widths[i]  = (m_Widths[0]  + (div - 1)) / div;
-                m_Heights[i] = (m_Heights[0] + (div - 1)) / div;
                 m_ScaledWidths[i]  = (m_ScaledWidths[0]  + (div - 1)) / div;
                 m_ScaledHeights[i] = (m_ScaledHeights[0] + (div - 1)) / div;
             }
@@ -186,7 +180,7 @@ namespace UnityEngine.Rendering.PostProcessing
         }
 
         void PushAllocCommands(CommandBuffer cmd, bool isMSAA)
-        { 
+        {
             if(isMSAA)
             {
                 Alloc(cmd, ShaderIDs.LinearDepth, MipLevel.Original, RenderTextureFormat.RGHalf, true);

--- a/PostProcessing/Runtime/Effects/MultiScaleVO.cs
+++ b/PostProcessing/Runtime/Effects/MultiScaleVO.cs
@@ -42,6 +42,9 @@ namespace UnityEngine.Rendering.PostProcessing
 
         readonly int[] m_Widths = new int[7];
         readonly int[] m_Heights = new int[7];
+        // Scaled dimensions used with dynamic resolution
+        readonly int[] m_ScaledWidths = new int[7];
+        readonly int[] m_ScaledHeights = new int[7];
 
         AmbientOcclusion m_Settings;
         PropertySheet m_PropertySheet;
@@ -79,8 +82,8 @@ namespace UnityEngine.Rendering.PostProcessing
             int sizeId = (int)size;
             cmd.GetTemporaryRT(id, new RenderTextureDescriptor
             {
-                width = m_Widths[sizeId],
-                height = m_Heights[sizeId],
+                width = m_ScaledWidths[sizeId],
+                height = m_ScaledHeights[sizeId],
                 colorFormat = format,
                 depthBufferBits = 0,
                 volumeDepth = 1,
@@ -97,8 +100,8 @@ namespace UnityEngine.Rendering.PostProcessing
             int sizeId = (int)size;
             cmd.GetTemporaryRT(id, new RenderTextureDescriptor
             {
-                width = m_Widths[sizeId],
-                height = m_Heights[sizeId],
+                width = m_ScaledWidths[sizeId],
+                height = m_ScaledHeights[sizeId],
                 colorFormat = format,
                 depthBufferBits = 0,
                 volumeDepth = 16,
@@ -135,26 +138,30 @@ namespace UnityEngine.Rendering.PostProcessing
 
         Vector2 GetSize(MipLevel mip)
         {
-            return new Vector2(m_Widths[(int)mip], m_Heights[(int)mip]);
+            return new Vector2(m_ScaledWidths[(int)mip], m_ScaledHeights[(int)mip]);
         }
 
         Vector3 GetSizeArray(MipLevel mip)
         {
-            return new Vector3(m_Widths[(int)mip], m_Heights[(int)mip], 16);
+            return new Vector3(m_ScaledWidths[(int)mip], m_ScaledHeights[(int)mip], 16);
         }
 
         public void GenerateAOMap(CommandBuffer cmd, Camera camera, RenderTargetIdentifier destination, RenderTargetIdentifier? depthMap, bool invert, bool isMSAA)
         {
-            // Base size
+            // Base size          
             m_Widths[0] = camera.pixelWidth * (RuntimeUtilities.isSinglePassStereoEnabled ? 2 : 1);
             m_Heights[0] = camera.pixelHeight;
-
+            m_ScaledWidths[0] = camera.scaledPixelWidth * (RuntimeUtilities.isSinglePassStereoEnabled ? 2 : 1);
+            m_ScaledHeights[0] = camera.scaledPixelHeight;
+            
             // L1 -> L6 sizes
             for (int i = 1; i < 7; i++)
             {
                 int div = 1 << i;
                 m_Widths[i]  = (m_Widths[0]  + (div - 1)) / div;
                 m_Heights[i] = (m_Heights[0] + (div - 1)) / div;
+                m_ScaledWidths[i]  = (m_ScaledWidths[0]  + (div - 1)) / div;
+                m_ScaledHeights[i] = (m_ScaledHeights[0] + (div - 1)) / div;
             }
 
             // Allocate temporary textures
@@ -179,7 +186,7 @@ namespace UnityEngine.Rendering.PostProcessing
         }
 
         void PushAllocCommands(CommandBuffer cmd, bool isMSAA)
-        {
+        { 
             if(isMSAA)
             {
                 Alloc(cmd, ShaderIDs.LinearDepth, MipLevel.Original, RenderTextureFormat.RGHalf, true);
@@ -266,7 +273,7 @@ namespace UnityEngine.Rendering.PostProcessing
             cmd.SetComputeVectorParam(cs, "ZBufferParams", CalculateZBufferParams(camera));
             cmd.SetComputeTextureParam(cs, kernel, "Depth", depthMapId);
 
-            cmd.DispatchCompute(cs, kernel, m_Widths[(int)MipLevel.L4], m_Heights[(int)MipLevel.L4], 1);
+            cmd.DispatchCompute(cs, kernel, m_ScaledWidths[(int)MipLevel.L4], m_ScaledHeights[(int)MipLevel.L4], 1);
 
             if (needDepthMapRelease)
                 Release(cmd, ShaderIDs.DepthCopy);
@@ -281,7 +288,7 @@ namespace UnityEngine.Rendering.PostProcessing
             cmd.SetComputeTextureParam(cs, kernel, "DS8xAtlas", ShaderIDs.TiledDepth3);
             cmd.SetComputeTextureParam(cs, kernel, "DS16xAtlas", ShaderIDs.TiledDepth4);
 
-            cmd.DispatchCompute(cs, kernel, m_Widths[(int)MipLevel.L6], m_Heights[(int)MipLevel.L6], 1);
+            cmd.DispatchCompute(cs, kernel, m_ScaledWidths[(int)MipLevel.L6], m_ScaledHeights[(int)MipLevel.L6], 1);
         }
 
         void PushRenderCommands(CommandBuffer cmd, int source, int destination, Vector3 sourceSize, float tanHalfFovH, bool isMSAA)
@@ -451,7 +458,8 @@ namespace UnityEngine.Rendering.PostProcessing
 
         void CheckAOTexture(PostProcessRenderContext context)
         {
-            if (m_AmbientOnlyAO == null || !m_AmbientOnlyAO.IsCreated() || m_AmbientOnlyAO.width != context.width || m_AmbientOnlyAO.height != context.height)
+            if (m_AmbientOnlyAO == null || !m_AmbientOnlyAO.IsCreated() || m_AmbientOnlyAO.width != context.width || m_AmbientOnlyAO.height != context.height ||
+                m_AmbientOnlyAO.useDynamicScale != context.camera.allowDynamicResolution)
             {
                 RuntimeUtilities.Destroy(m_AmbientOnlyAO);
 
@@ -459,7 +467,8 @@ namespace UnityEngine.Rendering.PostProcessing
                 {
                     hideFlags = HideFlags.DontSave,
                     filterMode = FilterMode.Point,
-                    enableRandomWrite = true
+                    enableRandomWrite = true,
+                    useDynamicScale = context.camera.allowDynamicResolution
                 };
                 m_AmbientOnlyAO.Create();
             }

--- a/PostProcessing/Runtime/Effects/SubpixelMorphologicalAntialiasing.cs
+++ b/PostProcessing/Runtime/Effects/SubpixelMorphologicalAntialiasing.cs
@@ -63,8 +63,8 @@ namespace UnityEngine.Rendering.PostProcessing
             var cmd = context.command;
             cmd.BeginSample("SubpixelMorphologicalAntialiasing");
 
-            cmd.GetTemporaryRT(ShaderIDs.SMAA_Flip, context.width, context.height, 0, FilterMode.Bilinear, context.sourceFormat, RenderTextureReadWrite.Linear);
-            cmd.GetTemporaryRT(ShaderIDs.SMAA_Flop, context.width, context.height, 0, FilterMode.Bilinear, context.sourceFormat, RenderTextureReadWrite.Linear);
+            cmd.GetTemporaryRT(ShaderIDs.SMAA_Flip, context.width, context.height, 0, FilterMode.Bilinear, context.sourceFormat, RenderTextureReadWrite.Linear, 1, false, RenderTextureMemoryless.None, context.camera.allowDynamicResolution);
+            cmd.GetTemporaryRT(ShaderIDs.SMAA_Flop, context.width, context.height, 0, FilterMode.Bilinear, context.sourceFormat, RenderTextureReadWrite.Linear, 1, false, RenderTextureMemoryless.None, context.camera.allowDynamicResolution);
 
             cmd.BlitFullscreenTriangle(context.source, ShaderIDs.SMAA_Flip, sheet, (int)Pass.EdgeDetection + (int)quality, true);
             cmd.BlitFullscreenTriangle(ShaderIDs.SMAA_Flip, ShaderIDs.SMAA_Flop, sheet, (int)Pass.BlendWeights + (int)quality);

--- a/PostProcessing/Runtime/Effects/SubpixelMorphologicalAntialiasing.cs
+++ b/PostProcessing/Runtime/Effects/SubpixelMorphologicalAntialiasing.cs
@@ -63,8 +63,13 @@ namespace UnityEngine.Rendering.PostProcessing
             var cmd = context.command;
             cmd.BeginSample("SubpixelMorphologicalAntialiasing");
 
+#if UNITY_2017_3_OR_NEWER
             cmd.GetTemporaryRT(ShaderIDs.SMAA_Flip, context.width, context.height, 0, FilterMode.Bilinear, context.sourceFormat, RenderTextureReadWrite.Linear, 1, false, RenderTextureMemoryless.None, context.camera.allowDynamicResolution);
             cmd.GetTemporaryRT(ShaderIDs.SMAA_Flop, context.width, context.height, 0, FilterMode.Bilinear, context.sourceFormat, RenderTextureReadWrite.Linear, 1, false, RenderTextureMemoryless.None, context.camera.allowDynamicResolution);
+#else
+            cmd.GetTemporaryRT(ShaderIDs.SMAA_Flip, context.width, context.height, 0, FilterMode.Bilinear, context.sourceFormat, RenderTextureReadWrite.Linear, 1, false);
+            cmd.GetTemporaryRT(ShaderIDs.SMAA_Flop, context.width, context.height, 0, FilterMode.Bilinear, context.sourceFormat, RenderTextureReadWrite.Linear, 1, false);
+#endif            
 
             cmd.BlitFullscreenTriangle(context.source, ShaderIDs.SMAA_Flip, sheet, (int)Pass.EdgeDetection + (int)quality, true);
             cmd.BlitFullscreenTriangle(ShaderIDs.SMAA_Flip, ShaderIDs.SMAA_Flop, sheet, (int)Pass.BlendWeights + (int)quality);

--- a/PostProcessing/Runtime/PostProcessLayer.cs
+++ b/PostProcessing/Runtime/PostProcessLayer.cs
@@ -244,7 +244,7 @@ namespace UnityEngine.Rendering.PostProcessing
         [ImageEffectUsesCommandBuffer]
         void OnRenderImage(RenderTexture src, RenderTexture dst)
         {
-            if (finalBlitToCameraTarget)
+            if (finalBlitToCameraTarget && (m_Camera.allowDynamicResolution && ScalableBufferManager.heightScaleFactor == 1.0 && ScalableBufferManager.widthScaleFactor == 1.0))
                 RenderTexture.active = dst; // silence warning
             else
                 Graphics.Blit(src, dst);
@@ -607,7 +607,7 @@ namespace UnityEngine.Rendering.PostProcessing
             context.destination = cameraTarget;
 
 #if UNITY_2019_1_OR_NEWER
-            if (finalBlitToCameraTarget && !RuntimeUtilities.scriptableRenderPipelineActive)
+            if (finalBlitToCameraTarget && !RuntimeUtilities.scriptableRenderPipelineActive && (!m_Camera.allowDynamicResolution || (ScalableBufferManager.heightScaleFactor == 1.0 && ScalableBufferManager.widthScaleFactor == 1.0)))
             {
                 if (m_Camera.targetTexture)
                 {

--- a/PostProcessing/Runtime/PostProcessLayer.cs
+++ b/PostProcessing/Runtime/PostProcessLayer.cs
@@ -237,6 +237,10 @@ namespace UnityEngine.Rendering.PostProcessing
             m_CurrentContext = new PostProcessRenderContext();
         }
 
+        bool DynamicResolutionAllowsFinalBlitToCameraTarget()
+        { 
+            return (!m_Camera.allowDynamicResolution || (ScalableBufferManager.heightScaleFactor == 1.0 && ScalableBufferManager.widthScaleFactor == 1.0));
+        }
 
 #if UNITY_2019_1_OR_NEWER
         // We always use a CommandBuffer to blit to the final render target
@@ -244,7 +248,7 @@ namespace UnityEngine.Rendering.PostProcessing
         [ImageEffectUsesCommandBuffer]
         void OnRenderImage(RenderTexture src, RenderTexture dst)
         {
-            if (finalBlitToCameraTarget && (m_Camera.allowDynamicResolution && ScalableBufferManager.heightScaleFactor == 1.0 && ScalableBufferManager.widthScaleFactor == 1.0))
+            if (finalBlitToCameraTarget && DynamicResolutionAllowsFinalBlitToCameraTarget())
                 RenderTexture.active = dst; // silence warning
             else
                 Graphics.Blit(src, dst);
@@ -607,7 +611,7 @@ namespace UnityEngine.Rendering.PostProcessing
             context.destination = cameraTarget;
 
 #if UNITY_2019_1_OR_NEWER
-            if (finalBlitToCameraTarget && !RuntimeUtilities.scriptableRenderPipelineActive && (!m_Camera.allowDynamicResolution || (ScalableBufferManager.heightScaleFactor == 1.0 && ScalableBufferManager.widthScaleFactor == 1.0)))
+            if (finalBlitToCameraTarget && !RuntimeUtilities.scriptableRenderPipelineActive && DynamicResolutionAllowsFinalBlitToCameraTarget())
             {
                 if (m_Camera.targetTexture)
                 {

--- a/PostProcessing/Runtime/PostProcessLayer.cs
+++ b/PostProcessing/Runtime/PostProcessLayer.cs
@@ -237,10 +237,12 @@ namespace UnityEngine.Rendering.PostProcessing
             m_CurrentContext = new PostProcessRenderContext();
         }
 
+#if UNITY_2019_1_OR_NEWER
         bool DynamicResolutionAllowsFinalBlitToCameraTarget()
         { 
             return (!m_Camera.allowDynamicResolution || (ScalableBufferManager.heightScaleFactor == 1.0 && ScalableBufferManager.widthScaleFactor == 1.0));
         }
+#endif
 
 #if UNITY_2019_1_OR_NEWER
         // We always use a CommandBuffer to blit to the final render target

--- a/PostProcessing/Runtime/PostProcessRenderContext.cs
+++ b/PostProcessing/Runtime/PostProcessRenderContext.cs
@@ -322,7 +322,7 @@ namespace UnityEngine.Rendering.PostProcessing
         // size usages explicit
 #if UNITY_2017_2_OR_NEWER
         RenderTextureDescriptor m_sourceDescriptor;
-        RenderTextureDescriptor GetDescriptor(int depthBufferBits = 0, RenderTextureFormat colorFormat = RenderTextureFormat.Default, RenderTextureReadWrite readWrite = RenderTextureReadWrite.Default)
+        public RenderTextureDescriptor GetDescriptor(int depthBufferBits = 0, RenderTextureFormat colorFormat = RenderTextureFormat.Default, RenderTextureReadWrite readWrite = RenderTextureReadWrite.Default)
         {
             var modifiedDesc = new RenderTextureDescriptor(m_sourceDescriptor.width, m_sourceDescriptor.height,
                                                                                 m_sourceDescriptor.colorFormat, depthBufferBits);
@@ -336,6 +336,11 @@ namespace UnityEngine.Rendering.PostProcessing
             modifiedDesc.autoGenerateMips = m_sourceDescriptor.autoGenerateMips;
             modifiedDesc.enableRandomWrite = m_sourceDescriptor.enableRandomWrite;
             modifiedDesc.shadowSamplingMode = m_sourceDescriptor.shadowSamplingMode;
+
+#if UNITY_2019_1_OR_NEWER     
+            if (m_Camera.allowDynamicResolution)           
+                modifiedDesc.useDynamicScale = true;
+#endif
 
             if (colorFormat != RenderTextureFormat.Default)
                 modifiedDesc.colorFormat = colorFormat;
@@ -380,8 +385,12 @@ namespace UnityEngine.Rendering.PostProcessing
             //intermediates in VR are unchanged
             if (stereoActive && desc.dimension == Rendering.TextureDimension.Tex2DArray)
                desc.dimension = Rendering.TextureDimension.Tex2D;
-          
+            
+#if UNITY_2019_1_OR_NEWER
             cmd.GetTemporaryRT(nameID, desc, filter);
+#else
+            cmd.GetTemporaryRT(nameID, desc.width, desc.height, desc.depthBufferBits, filter, desc.colorFormat, readWrite, desc.msaaSamples, desc.enableRandomWrite, desc.memoryless, m_Camera.allowDynamicResolution);
+#endif
 #else
             int actualWidth = width;
             int actualHeight = height;

--- a/PostProcessing/Runtime/PostProcessRenderContext.cs
+++ b/PostProcessing/Runtime/PostProcessRenderContext.cs
@@ -322,6 +322,13 @@ namespace UnityEngine.Rendering.PostProcessing
         // size usages explicit
 #if UNITY_2017_2_OR_NEWER
         RenderTextureDescriptor m_sourceDescriptor;
+        /// <summary>
+        /// Returns a modified copy the RenderTextureDescriptor used by the context object. 
+        /// </summary>
+        /// <param name="depthBufferBits">The number of bits to use for the depth buffer</param>
+        /// <param name="colorFormat">The render texture format</param>
+        /// <param name="readWrite">The color space conversion mode</param>
+        /// <returns>A RenderTextureDescriptor object</returns>
         public RenderTextureDescriptor GetDescriptor(int depthBufferBits = 0, RenderTextureFormat colorFormat = RenderTextureFormat.Default, RenderTextureReadWrite readWrite = RenderTextureReadWrite.Default)
         {
             var modifiedDesc = new RenderTextureDescriptor(m_sourceDescriptor.width, m_sourceDescriptor.height,

--- a/PostProcessing/Runtime/PostProcessRenderContext.cs
+++ b/PostProcessing/Runtime/PostProcessRenderContext.cs
@@ -395,8 +395,10 @@ namespace UnityEngine.Rendering.PostProcessing
             
 #if UNITY_2019_1_OR_NEWER
             cmd.GetTemporaryRT(nameID, desc, filter);
-#else
+#elif UNITY_2017_3_OR_NEWER
             cmd.GetTemporaryRT(nameID, desc.width, desc.height, desc.depthBufferBits, filter, desc.colorFormat, readWrite, desc.msaaSamples, desc.enableRandomWrite, desc.memoryless, m_Camera.allowDynamicResolution);
+#else
+            cmd.GetTemporaryRT(nameID, desc.width, desc.height, desc.depthBufferBits, filter, desc.colorFormat, readWrite, desc.msaaSamples, desc.enableRandomWrite, desc.memoryless);
 #endif
 #else
             int actualWidth = width;


### PR DESCRIPTION
Mostly, I've changed CreateTemporaryRT() to use the allowDynamicResolution flag from the camera object assigned to the post process render context. It's complicated a little by useDynamicScale not being fully exposed in before 19.1.

Some effects needed extra changes because they don't use the utility functions in the post process context but those changes mirror what has been changed there.