### PR TITLE
Update deprecated XR API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.2.3] - 2019-11-15
+- Fixed deprecated XR API usage.
+
 ## [2.2.2] - 2019-XX-XX
 
 ## [2.2.1] - 2019-11-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.2.3] - 2019-11-15
-- Fixed deprecated XR API usage.
+## [2.2.2] - 2019-11-18
 
-## [2.2.2] - 2019-XX-XX
+### Fixed
+- Fixed deprecated XR API usage.
 
 ## [2.2.1] - 2019-11-07
 

--- a/PostProcessing/Runtime/Utils/RuntimeUtilities.cs
+++ b/PostProcessing/Runtime/Utils/RuntimeUtilities.cs
@@ -772,13 +772,13 @@ namespace UnityEngine.Rendering.PostProcessing
         }
 #endif
 
-                /// <summary>
-                /// Returns <c>true</c> if single-pass stereo rendering is active, <c>false</c> otherwise.
-                /// </summary>
-                /// <remarks>
-                /// This property only works in the editor.
-                /// </remarks>
-                // TODO: Check for SPSR support at runtime
+        /// <summary>
+        /// Returns <c>true</c> if single-pass stereo rendering is active, <c>false</c> otherwise.
+        /// </summary>
+        /// <remarks>
+        /// This property only works in the editor.
+        /// </remarks>
+        // TODO: Check for SPSR support at runtime
         public static bool isSinglePassStereoEnabled
         {
             get

--- a/PostProcessing/Runtime/Utils/RuntimeUtilities.cs
+++ b/PostProcessing/Runtime/Utils/RuntimeUtilities.cs
@@ -751,7 +751,7 @@ namespace UnityEngine.Rendering.PostProcessing
             get { return scriptableRenderPipelineActive || GraphicsSettings.GetShaderMode(BuiltinShaderType.DepthNormals) != BuiltinShaderMode.Disabled; }
         }
 
-#if UNITY_EDITOR 
+#if UNITY_EDITOR
         /// <summary>
         /// Returns <c>true</c> if single-pass stereo rendering is selected, <c>false</c> otherwise.
         /// </summary>

--- a/PostProcessing/Runtime/Utils/RuntimeUtilities.cs
+++ b/PostProcessing/Runtime/Utils/RuntimeUtilities.cs
@@ -751,7 +751,7 @@ namespace UnityEngine.Rendering.PostProcessing
             get { return scriptableRenderPipelineActive || GraphicsSettings.GetShaderMode(BuiltinShaderType.DepthNormals) != BuiltinShaderMode.Disabled; }
         }
 
-#if UNITY_EDITOR
+#if UNITY_EDITOR 
         /// <summary>
         /// Returns <c>true</c> if single-pass stereo rendering is selected, <c>false</c> otherwise.
         /// </summary>
@@ -762,19 +762,23 @@ namespace UnityEngine.Rendering.PostProcessing
         {
             get
             {
-                return PlayerSettings.virtualRealitySupported
+#if ENABLE_VR && !UNITY_2020_1_OR_NEWER
+                return UnityEditorInternal.VR.VREditor.GetVREnabledOnTargetGroup(BuildPipeline.GetBuildTargetGroup(EditorUserBuildSettings.activeBuildTarget))
                     && PlayerSettings.stereoRenderingPath == UnityEditor.StereoRenderingPath.SinglePass;
+#else
+                return false;
+#endif
             }
         }
 #endif
 
-        /// <summary>
-        /// Returns <c>true</c> if single-pass stereo rendering is active, <c>false</c> otherwise.
-        /// </summary>
-        /// <remarks>
-        /// This property only works in the editor.
-        /// </remarks>
-        // TODO: Check for SPSR support at runtime
+                /// <summary>
+                /// Returns <c>true</c> if single-pass stereo rendering is active, <c>false</c> otherwise.
+                /// </summary>
+                /// <remarks>
+                /// This property only works in the editor.
+                /// </remarks>
+                // TODO: Check for SPSR support at runtime
         public static bool isSinglePassStereoEnabled
         {
             get
@@ -796,8 +800,8 @@ namespace UnityEngine.Rendering.PostProcessing
         {
             get
             {
-#if UNITY_EDITOR
-                return UnityEditor.PlayerSettings.virtualRealitySupported;
+#if ENABLE_VR && UNITY_EDITOR && !UNITY_2020_1_OR_NEWER
+                return UnityEditorInternal.VR.VREditor.GetVREnabledOnTargetGroup(BuildPipeline.GetBuildTargetGroup(EditorUserBuildSettings.activeBuildTarget));
 #elif UNITY_XBOXONE || !ENABLE_VR
                 return false;
 #else

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.unity.postprocessing",
-    "version": "2.2.3",
+    "version": "2.2.2",
     "displayName": "Post Processing",
     "unity": "2018.1",
     "description": "The post-processing stack (v2) comes with a collection of effects and image filters you can apply to your cameras to improve the visuals of your games.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.unity.postprocessing",
-    "version": "2.2.2",
+    "version": "2.2.3",
     "displayName": "Post Processing",
     "unity": "2018.1",
     "description": "The post-processing stack (v2) comes with a collection of effects and image filters you can apply to your cameras to improve the visuals of your games.",


### PR DESCRIPTION
Change deprecated XR API usage to internal API to prevent any warnings from showing up when the package is installed. Also prevent the use of the API on 2020.1 as both APIs will be removed.