### PR TITLE
[XR] Fix for multipass rendering with legacy built-in renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Fixed deprecated XR API usage.
+- Fix for XR multipass and legacy built-in renderer (case 1197855, 1152584)
 
 ## [2.2.1] - 2019-11-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.2.3] - 0000-00-00
+
+### Fixed
+- Fix for XR multipass and legacy built-in renderer (case 1197855, 1152584)
+
 ## [2.2.2] - 2019-11-18
 
 ### Fixed
 - Fixed deprecated XR API usage.
-- Fix for XR multipass and legacy built-in renderer (case 1197855, 1152584)
 
 ## [2.2.1] - 2019-11-07
 

--- a/PostProcessing/Runtime/PostProcessRenderContext.cs
+++ b/PostProcessing/Runtime/PostProcessRenderContext.cs
@@ -31,6 +31,12 @@ namespace UnityEngine.Rendering.PostProcessing
                 {
                     var xrDesc = XRSettings.eyeTextureDesc;
                     stereoRenderingMode = StereoRenderingMode.SinglePass;
+                    numberOfEyes = 1;
+
+#if UNITY_2018_3_OR_NEWER
+                    if (XRSettings.stereoRenderingMode == XRSettings.StereoRenderingMode.MultiPass)
+                        stereoRenderingMode = StereoRenderingMode.MultiPass;
+#endif
 
 #if UNITY_STANDALONE || UNITY_EDITOR
                     if (xrDesc.dimension == TextureDimension.Tex2DArray)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.unity.postprocessing",
-    "version": "2.2.2",
+    "version": "2.2.3",
     "displayName": "Post Processing",
     "unity": "2018.1",
     "description": "The post-processing stack (v2) comes with a collection of effects and image filters you can apply to your cameras to improve the visuals of your games.",


### PR DESCRIPTION

Fix for XR multipass and legacy built-in renderer. 
https://fogbugz.unity3d.com/f/cases/1152584
https://fogbugz.unity3d.com/f/cases/1198805

Tested with:
1. 2019.3 and built-in renderer on Rift
2. 2019.2 with lightweight renderer on Rift

QA @ryanhy-unity 
