### PR TITLE
Fix VR Single Pass Instancing when using built-in renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.3.1] - 2020-XX-XX
 
+### Fixed
+- Fix for VR Single Pass Instancing (SPI) not working with the built-in renderers. Only effects that currently support SPI for use with SRP will work correctly (so AO for example will not work with SPI even with this fix) (case 1187257)
+
 ## [2.3.0] - 2020-01-10
 
 ### Fixed

--- a/PostProcessing/Runtime/PostProcessLayer.cs
+++ b/PostProcessing/Runtime/PostProcessLayer.cs
@@ -620,7 +620,8 @@ namespace UnityEngine.Rendering.PostProcessing
             // Post-transparency stack
             int tempRt = -1;
             bool forceNanKillPass = (!m_NaNKilled && stopNaNPropagation && RuntimeUtilities.isFloatingPointFormat(sourceFormat));
-            if (RequiresInitialBlit(m_Camera, context) || forceNanKillPass)
+            bool vrSinglePassInstancingEnabled = context.stereoActive && context.numberOfEyes > 1 && context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePassInstanced;
+            if (!vrSinglePassInstancingEnabled && (RequiresInitialBlit(m_Camera, context) || forceNanKillPass))
             {
                 tempRt = m_TargetPool.Get();
                 context.GetScreenSpaceTemporaryRT(m_LegacyCmdBuffer, tempRt, 0, sourceFormat, RenderTextureReadWrite.sRGB);

--- a/PostProcessing/Runtime/PostProcessRenderContext.cs
+++ b/PostProcessing/Runtime/PostProcessRenderContext.cs
@@ -38,7 +38,7 @@ namespace UnityEngine.Rendering.PostProcessing
                         stereoRenderingMode = StereoRenderingMode.MultiPass;
 #endif
 
-#if UNITY_STANDALONE || UNITY_EDITOR
+#if UNITY_STANDALONE || UNITY_EDITOR || UNITY_PS4
                     if (xrDesc.dimension == TextureDimension.Tex2DArray)
                         stereoRenderingMode = StereoRenderingMode.SinglePassInstanced;
 #endif


### PR DESCRIPTION
This PR fixes VR Single Pass Instancing not working when using the built-in renderer.

VR Single Pass Instancing was fixed to work a while ago for use in LWRP but there are extra copy stages involved when using the built-in render pipeline that have not been converted to be texture array aware and so breaks when SPI is used.

This PR disables the extra copy when doing VR SPI so we flow through the path that is SPI aware. This fixes VR SPI with the built-in renderer for PlayStation VR and for the Mock HMD (Windows) on 2019.3.

Any effects that were not converted to be SPI aware for use in SRP such as AO will still not work correctly if enabled.