### PR TITLE
Enable Motion Blur and Lens Distortion for non-stereo cameras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fix for VR Single Pass Instancing (SPI) not working with the built-in renderers. Only effects that currently support SPI for use with SRP will work correctly (so AO for example will not work with SPI even with this fix) (case 1187257)
 
+### Changed
+- Motion Blur and Lens Distortion are disabled only when rendering with stereo cameras instead of having VR enabled in the project.
+
 ## [2.3.0] - 2020-01-10
 
 ### Fixed

--- a/PostProcessing/Editor/Effects/MotionBlurEditor.cs
+++ b/PostProcessing/Editor/Effects/MotionBlurEditor.cs
@@ -2,13 +2,13 @@ using UnityEngine.Rendering.PostProcessing;
 
 namespace UnityEditor.Rendering.PostProcessing
 {
-    [PostProcessEditor(typeof(LensDistortion))]
-    internal sealed class LensDistortionEditor : DefaultPostProcessEffectEditor
+    [PostProcessEditor(typeof(MotionBlur))]
+    internal sealed class MotionBlurEditor : DefaultPostProcessEffectEditor
     {
         public override void OnInspectorGUI()
         {
             if (RuntimeUtilities.isVREnabled)
-                EditorGUILayout.HelpBox("Lens Distortion is available only for non-stereo cameras.", MessageType.Warning);
+                EditorGUILayout.HelpBox("Motion Blur is available only for non-stereo cameras.", MessageType.Warning);
 
             base.OnInspectorGUI();
         }

--- a/PostProcessing/Editor/Effects/MotionBlurEditor.cs.meta
+++ b/PostProcessing/Editor/Effects/MotionBlurEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: de3d46fc4bda066408aeba6fb8e44d6a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/PostProcessing/Runtime/Effects/LensDistortion.cs
+++ b/PostProcessing/Runtime/Effects/LensDistortion.cs
@@ -57,7 +57,7 @@ namespace UnityEngine.Rendering.PostProcessing
             return enabled.value
                 && !Mathf.Approximately(intensity, 0f)
                 && (intensityX > 0f || intensityY > 0f)
-                && !RuntimeUtilities.isVREnabled;
+                && !context.stereoActive;
         }
     }
 

--- a/PostProcessing/Runtime/Effects/MotionBlur.cs
+++ b/PostProcessing/Runtime/Effects/MotionBlur.cs
@@ -38,7 +38,7 @@ namespace UnityEngine.Rendering.PostProcessing
             #endif
                 && SystemInfo.supportsMotionVectors
                 && RenderTextureFormat.RGHalf.IsSupported()
-                && !RuntimeUtilities.isVREnabled;
+                && !context.stereoActive;
         }
     }
 


### PR DESCRIPTION
This allows applying those effects to spectator or other special-purpose cameras in VR projects. Added Motion Blur editor to have a matching warning in both.