### PR TITLE
Added TAA check for ResetProjection Matrix

### DIFF
--- a/PostProcessing/Runtime/PostProcessLayer.cs
+++ b/PostProcessing/Runtime/PostProcessLayer.cs
@@ -440,11 +440,13 @@ namespace UnityEngine.Rendering.PostProcessing
             // We also need to force reset the non-jittered projection matrix here as it's not done
             // when ResetProjectionMatrix() is called and will break transparent rendering if TAA
             // is switched off and the FOV or any other camera property changes.
-
+            if (m_CurrentContext.IsTemporalAntialiasingActive())
+            {
 #if UNITY_2018_2_OR_NEWER
             if (!m_Camera.usePhysicalProperties)
 #endif
                 m_Camera.ResetProjectionMatrix();
+            }
             m_Camera.nonJitteredProjectionMatrix = m_Camera.projectionMatrix;
 
 #if ENABLE_VR


### PR DESCRIPTION
Without this check, projection rest occurs every frame regardless of AA setting. This breaks our custom projections calculations and similar XR solutions that both have calculated matrics and PPSv2.

-Joe Lang, Leia Inc