### PR TITLE
[XR] Fix for Temporal Anti-Aliasing produces artifacts on the edges of objects when using VR (case 1167219)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.4.1] - 2020-XX-XX
-
-### Fixed
-- Fix for Temporal Anti-Aliasing produces artifacts on the edges of objects when using VR (case 1167219)
-
-## [2.4.0] - 2020-09-01
+## [2.4.0] - 2020-09-03
 
 ### Fixed
 - Fix for VR Single Pass Instancing (SPI) not working with the built-in renderers. Only effects that currently support SPI for use with SRP will work correctly (so AO for example will not work with SPI even with this fix) (case 1187257)
@@ -19,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix for burger buttons on volume components being misaligned on 2019.3+ (case 1238461)
 - Fix for depth buffer being discarded when using deferred fog with Vulkan (case 1271512)
 - Fix for compilation errors when the built-in VR package is disabled (case 1266931)
+- Fix for Temporal Anti-Aliasing produces artifacts on the edges of objects when using VR (case 1167219)
 
 ### Changed
 - Motion Blur and Lens Distortion are disabled only when rendering with stereo cameras instead of having VR enabled in the project.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.4.1] - 2020-XX-XX
+
+### Fixed
+- Fix for Temporal Anti-Aliasing produces artifacts on the edges of objects when using VR (case 1167219)
+
 ## [2.4.0] - 2020-09-01
 
 ### Fixed

--- a/PostProcessing/Runtime/PostProcessLayer.cs
+++ b/PostProcessing/Runtime/PostProcessLayer.cs
@@ -939,6 +939,9 @@ namespace UnityEngine.Rendering.PostProcessing
             RenderTargetIdentifier cameraTexture = context.source;
 
 #if UNITY_2019_1_OR_NEWER
+            if (context.stereoActive)
+                context.UpdateStereoTAA();
+
             if (context.stereoActive && context.numberOfEyes > 1 && context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePass)
             {
                 cmd.SetSinglePassStereo(SinglePassStereoMode.None);

--- a/PostProcessing/Runtime/PostProcessRenderContext.cs
+++ b/PostProcessing/Runtime/PostProcessRenderContext.cs
@@ -415,5 +415,29 @@ namespace UnityEngine.Rendering.PostProcessing
 
             return RenderTexture.GetTemporary(desc);
         }
+
+        /// <summary>
+        /// Update current single-pass stereo state for TAA
+        /// </summary>
+        public void UpdateStereoTAA()
+        {
+#if UNITY_2019_1_OR_NEWER
+            screenWidth = XRSettings.eyeTextureWidth;
+
+            if (stereoRenderingMode == StereoRenderingMode.SinglePass)
+            {
+                //When TAA is active, disable XR single-pass interface
+                if (IsTemporalAntialiasingActive())
+                {
+                    numberOfEyes = 1;
+                }
+                else
+                {
+                    numberOfEyes = 2;
+                    screenWidth /= 2;
+                }
+            }
+#endif
+        }
     }
 }


### PR DESCRIPTION
When TAA and single-pass is enabled, disable XR interface and switch to the old single-pass stereo method.

fogbugz case: https://fogbugz.unity3d.com/f/cases/1167219/

Tested on legacy built-in renderer on Oculus Rift with multipass/single-pass.
