### PR TITLE
[XR] Fix for blurry image when using the Post Process Layer in single-pass VR (cases 1173697, 1237102).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.4.0] - 2020-09-03
+## [2.4.0] - 2020-09-09
 
 ### Fixed
 - Fix for VR Single Pass Instancing (SPI) not working with the built-in renderers. Only effects that currently support SPI for use with SRP will work correctly (so AO for example will not work with SPI even with this fix) (case 1187257)
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix for depth buffer being discarded when using deferred fog with Vulkan (case 1271512)
 - Fix for compilation errors when the built-in VR package is disabled (case 1266931)
 - Fix for Temporal Anti-Aliasing produces artifacts on the edges of objects when using VR (case 1167219)
+- Fix for blurry image when using the Post Process Layer in single-pass VR (case 1173697)
 
 ### Changed
 - Motion Blur and Lens Distortion are disabled only when rendering with stereo cameras instead of having VR enabled in the project.

--- a/PostProcessing/Runtime/PostProcessLayer.cs
+++ b/PostProcessing/Runtime/PostProcessLayer.cs
@@ -623,8 +623,14 @@ namespace UnityEngine.Rendering.PostProcessing
             bool vrSinglePassInstancingEnabled = context.stereoActive && context.numberOfEyes > 1 && context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePassInstanced;
             if (!vrSinglePassInstancingEnabled && (RequiresInitialBlit(m_Camera, context) || forceNanKillPass))
             {
+                int width = context.width;
+#if UNITY_2019_1_OR_NEWER
+                var xrDesc = XRSettings.eyeTextureDesc;
+                if (context.stereoActive && context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePass)
+                   width = xrDesc.width;
+#endif
                 tempRt = m_TargetPool.Get();
-                context.GetScreenSpaceTemporaryRT(m_LegacyCmdBuffer, tempRt, 0, sourceFormat, RenderTextureReadWrite.sRGB);
+                context.GetScreenSpaceTemporaryRT(m_LegacyCmdBuffer, tempRt, 0, sourceFormat, RenderTextureReadWrite.sRGB, FilterMode.Bilinear, width);
                 m_LegacyCmdBuffer.BuiltinBlit(cameraTarget, tempRt, RuntimeUtilities.copyStdMaterial, stopNaNPropagation ? 1 : 0);
                 if (!m_NaNKilled)
                     m_NaNKilled = stopNaNPropagation;


### PR DESCRIPTION
For XR single-pass mode that requires initial blit, use full XR camera texture width for the initial blit. 

fogbugz cases: 
https://fogbugz.unity3d.com/f/cases/1173697  
https://fogbugz.unity3d.com/f/cases/1237102

Tested on legacy built-in renderer on Oculus Rift with single-pass and multipass.

