### PR TITLE
[XR] Fix for ambient occlusion is misaligned when using single pass rendering mode (case 1217583)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.4.0] - 2020-09-09
+## [2.4.0] - 2020-09-17
 
 ### Fixed
 - Fix for VR Single Pass Instancing (SPI) not working with the built-in renderers. Only effects that currently support SPI for use with SRP will work correctly (so AO for example will not work with SPI even with this fix) (case 1187257)
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix for compilation errors when the built-in VR package is disabled (case 1266931)
 - Fix for Temporal Anti-Aliasing produces artifacts on the edges of objects when using VR (case 1167219)
 - Fix for blurry image when using the Post Process Layer in single-pass VR (case 1173697)
+- Fix for ambient occlusion is misaligned when using single pass rendering VR mode (case 1217583)
 
 ### Changed
 - Motion Blur and Lens Distortion are disabled only when rendering with stereo cameras instead of having VR enabled in the project.

--- a/PostProcessing/Runtime/PostProcessLayer.cs
+++ b/PostProcessing/Runtime/PostProcessLayer.cs
@@ -551,6 +551,10 @@ namespace UnityEngine.Rendering.PostProcessing
             var ssrRenderer = ssrBundle.renderer;
             bool isScreenSpaceReflectionsActive = ssrSettings.IsEnabledAndSupported(context);
 
+#if UNITY_2019_1_OR_NEWER
+            if (context.stereoActive)
+                context.UpdateSinglePassStereoState(context.IsTemporalAntialiasingActive(), aoSupported, isScreenSpaceReflectionsActive);
+#endif
             // Ambient-only AO is a special case and has to be done in separate command buffers
             if (isAmbientOcclusionDeferred)
             {
@@ -945,9 +949,6 @@ namespace UnityEngine.Rendering.PostProcessing
             RenderTargetIdentifier cameraTexture = context.source;
 
 #if UNITY_2019_1_OR_NEWER
-            if (context.stereoActive)
-                context.UpdateStereoTAA();
-
             if (context.stereoActive && context.numberOfEyes > 1 && context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePass)
             {
                 cmd.SetSinglePassStereo(SinglePassStereoMode.None);

--- a/PostProcessing/Runtime/PostProcessRenderContext.cs
+++ b/PostProcessing/Runtime/PostProcessRenderContext.cs
@@ -45,21 +45,6 @@ namespace UnityEngine.Rendering.PostProcessing
                     if (stereoRenderingMode == StereoRenderingMode.SinglePassInstanced)
                         numberOfEyes = 2;
 
-#if UNITY_2019_1_OR_NEWER
-                    if (stereoRenderingMode == StereoRenderingMode.SinglePass)
-                    {
-                        numberOfEyes = 2;
-                        xrDesc.width /= 2;
-                        xrDesc.vrUsage = VRTextureUsage.None;
-                    }
-#else
-                    //before 2019.1 double-wide still issues two drawcalls
-                    if (stereoRenderingMode == StereoRenderingMode.SinglePass)
-                    {
-                        numberOfEyes = 1;
-                    }
-#endif
-
                     width = xrDesc.width;
                     height = xrDesc.height;
                     m_sourceDescriptor = xrDesc;
@@ -69,11 +54,6 @@ namespace UnityEngine.Rendering.PostProcessing
 
                     screenWidth = XRSettings.eyeTextureWidth;
                     screenHeight = XRSettings.eyeTextureHeight;
-
-#if UNITY_2019_1_OR_NEWER
-                    if (stereoRenderingMode == StereoRenderingMode.SinglePass)
-                        screenWidth /= 2;
-#endif
                     stereoActive = true;
 
                 }

--- a/PostProcessing/Runtime/PostProcessRenderContext.cs
+++ b/PostProcessing/Runtime/PostProcessRenderContext.cs
@@ -417,25 +417,36 @@ namespace UnityEngine.Rendering.PostProcessing
         }
 
         /// <summary>
-        /// Update current single-pass stereo state for TAA
+        /// Update current single-pass stereo state for TAA, AO, etc.
         /// </summary>
-        public void UpdateStereoTAA()
+        public void UpdateSinglePassStereoState(bool isTAAEnabled, bool isAOEnabled, bool isSSREnabled)
         {
 #if UNITY_2019_1_OR_NEWER
+            var xrDesc = XRSettings.eyeTextureDesc;
             screenWidth = XRSettings.eyeTextureWidth;
 
             if (stereoRenderingMode == StereoRenderingMode.SinglePass)
             {
-                //When TAA is active, disable XR single-pass interface
-                if (IsTemporalAntialiasingActive())
+                //For complex effects, it's more efficient to disable XR single-pass interface
+                if (isTAAEnabled || isAOEnabled || isSSREnabled)
                 {
                     numberOfEyes = 1;
                 }
                 else
                 {
+                    //Use XR-interface method:
+                    //We take care of providing stereoized camera render texture to postprocessing framework and rendering out the final postprocessed results to the each of the eye textures
+                    // https://docs.google.com/document/d/1hANbhKCRIJs6ww7XoAIXbX3ArdAs7OBOTfZL1MqgtPI
+
                     numberOfEyes = 2;
+                    xrDesc.width /= 2;
+                    xrDesc.vrUsage = VRTextureUsage.None;
                     screenWidth /= 2;
                 }
+
+                width = xrDesc.width;
+                height = xrDesc.height;
+                m_sourceDescriptor = xrDesc;
             }
 #endif
         }


### PR DESCRIPTION
Update single-pass stereo state for AO and SSR. For complex effects such as AO and SSR, it's more efficient to disable XR single-pass interface method. 
Refactored postfx v2 XR-interface context setup.

fogbugz case: https://fogbugz.unity3d.com/f/cases/1217583/

Tested with Oculus Rift + built-in renderer + 2019.4