### PR TITLE
Fix to reduce the amount of allocations required when using MSVO and Dynamic Resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2020-10-16
+### Fixed
+- Fix for MSVO when used with dynamic resolution reallocating temp render targets whenever the dynamic resolution scale was changed. Now those temp targets will use dynamic scaling as well. This will require a matching fix in Unity to work correctly (ADD COMPATIBLE VERSIONS HERE). (case XXXXXX).
+
 ## [3.0.0] - 2020-10-13
 
 ### Fixed

--- a/PostProcessing/Runtime/Effects/MultiScaleVO.cs
+++ b/PostProcessing/Runtime/Effects/MultiScaleVO.cs
@@ -81,10 +81,16 @@ namespace UnityEngine.Rendering.PostProcessing
         void Alloc(CommandBuffer cmd, int id, MipLevel size, RenderTextureFormat format, bool uav, bool dynamicScale)
         {
             int sizeId = (int)size;
+
             cmd.GetTemporaryRT(id, new RenderTextureDescriptor
             {
+#if UNITY_2019_4_OR_NEWER
                 width = m_Widths[sizeId],
                 height = m_Heights[sizeId],
+#else
+                width = m_ScaledWidths[sizeId],
+                height = m_ScaledHeights[sizeId],
+#endif
                 colorFormat = format,
                 depthBufferBits = 0,
                 volumeDepth = 1,
@@ -93,7 +99,7 @@ namespace UnityEngine.Rendering.PostProcessing
 #if UNITY_2019_2_OR_NEWER
                 mipCount = 1,
 #endif
-#if UNITY_2017_3_OR_NEWER
+#if UNITY_2019_4_OR_NEWER
                 useDynamicScale = dynamicScale,
 #endif
                 enableRandomWrite = uav,
@@ -105,10 +111,16 @@ namespace UnityEngine.Rendering.PostProcessing
         void AllocArray(CommandBuffer cmd, int id, MipLevel size, RenderTextureFormat format, bool uav, bool dynamicScale)
         {
             int sizeId = (int)size;
+
             cmd.GetTemporaryRT(id, new RenderTextureDescriptor
             {
+#if UNITY_2019_4_OR_NEWER
                 width = m_Widths[sizeId],
                 height = m_Heights[sizeId],
+#else
+                width = m_ScaledWidths[sizeId],
+                height = m_ScaledHeights[sizeId],
+#endif
                 colorFormat = format,
                 depthBufferBits = 0,
                 volumeDepth = 16,
@@ -117,7 +129,7 @@ namespace UnityEngine.Rendering.PostProcessing
 #if UNITY_2019_2_OR_NEWER
                 mipCount = 1,
 #endif
-#if UNITY_2017_3_OR_NEWER
+#if UNITY_2019_4_OR_NEWER
                 useDynamicScale = dynamicScale,
 #endif
                 enableRandomWrite = uav,

--- a/PostProcessing/Runtime/Effects/MultiScaleVO.cs
+++ b/PostProcessing/Runtime/Effects/MultiScaleVO.cs
@@ -180,16 +180,19 @@ namespace UnityEngine.Rendering.PostProcessing
             // Adjust the scaled dimensions based off the dynamic resolution resolution used at the moment.
             m_ScaledWidths[0] = camera.scaledPixelWidth * (RuntimeUtilities.isSinglePassStereoEnabled ? 2 : 1);
             m_ScaledHeights[0] = camera.scaledPixelHeight;
-#endif
-
+#endif            
+            float widthScalingFactor = ScalableBufferManager.widthScaleFactor;
+            float heightScalingFactor = ScalableBufferManager.heightScaleFactor;
             // L1 -> L6 sizes
             for (int i = 1; i < 7; i++)
             {
                 int div = 1 << i;
                 m_Widths[i] = (m_Widths[0] + (div - 1)) / div;
                 m_Heights[i] = (m_Heights[0] + (div - 1)) / div;
-                m_ScaledWidths[i]  = (m_ScaledWidths[0]  + (div - 1)) / div;
-                m_ScaledHeights[i] = (m_ScaledHeights[0] + (div - 1)) / div;
+                // Scaled width and heights have to match their calculations like will happen with dynamic resolution otherwise with odd numbers you can get a difference between what the dynamic resolution version
+                // generates and what we use here.
+                m_ScaledWidths[i] = Mathf.CeilToInt(m_Widths[i] * widthScalingFactor);
+                m_ScaledHeights[i] = Mathf.CeilToInt(m_Heights[i] * heightScalingFactor);
             }
 
             // Allocate temporary textures

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.unity.postprocessing",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "displayName": "Post Processing",
     "unity": "2018.4",
     "description": "The post-processing stack (v2) comes with a collection of effects and image filters you can apply to your cameras to improve the visuals of your games.",


### PR DESCRIPTION
The existing dynamic resolution strategy manually scales the temporary intermediate textures to the correct size required for the current dynamic resolution scale. This allows the effect to run correctly and for a given fixed scaling factor will keep the memory usage constant however if dynamic resolution is being scaled over time then every time it changes scaling factor the temporary intermediate textures will be reallocated causing an increase in memory pressure while this happens and possibly generating more VRAM fragmentation (depending on the platform).

This PR make the temporary intermediate textures be full size dynamic resolution textures themselves. The behavior of this PR and the existing behavior should match when dynamic resolution is *not* being used. However when dynamic resolution *is* being used this PR changes the following:
* We now allocate the temporary intermediate textures at full size all the time so for a fixed dynamic resolution scaling of 0.5 this PR will increase VRAM usage as we will now allocate all textures at 1.0 size and then make sure of dynamic resolution to access a 0.5 scaled version using the same memory.
* The temporary intermediate textures are now dynamic, this means they may have less chance of matching other temporary textures used by other systems and so increase the memory usage of this project.
* Changing the dynamic scaling factor will no longer cause these textures to be reallocated thus VRAM usage should be consistent no matter what level of dynamic scaling factor is used and reduce memory fragmentation and allocation overheads.

Fixing this behavior showed up a bug in how Unity handles viewport setting when using dynamic resolution on some render targets at least on PS4 and possibly other dynamic resolution platforms. This PR requires a fixed Unity version to work correctly otherwise the temporary intermediate textures are not rendered to correctly when the scale is not 1.0.