### PR TITLE
Fix for issue throw upon unloading a scene from AssetBundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.0.2] - XXXX-XX-XX
 
+### Fixed
+- Fix for issue throw upon unloading a scene from AssetBundle - "Invalid pass number (1) for Graphics.Blit error" (case 1262826)
+
 ### Changed
 - ResetProjection isn't being called anymore if Temporal Anti-aliasing isn't enabled, allowing the use of custom projection matrices.
 

--- a/PostProcessing/Runtime/PostProcessLayer.cs
+++ b/PostProcessing/Runtime/PostProcessLayer.cs
@@ -854,7 +854,11 @@ namespace UnityEngine.Rendering.PostProcessing
         {
             // Juggling required when a scene with post processing is loaded from an asset bundle
             // See #1148230
-            if (m_OldResources != m_Resources)
+            // Additional !RuntimeUtilities.isValidResources() for fixing issue #1262826
+            // The static member s_Resources is unset by addressable. The code is ill formed as it is not made to handle multiple scene.
+            // As the PPV2 is not develop anymore we will not rewrite the system but instead we force a re-init of this value so it is 
+            // in a correct state.
+            if (m_OldResources != m_Resources || !RuntimeUtilities.isValidResources())
             {
                 RuntimeUtilities.UpdateResources(m_Resources);
                 m_OldResources = m_Resources;

--- a/PostProcessing/Runtime/Utils/RuntimeUtilities.cs
+++ b/PostProcessing/Runtime/Utils/RuntimeUtilities.cs
@@ -381,6 +381,11 @@ namespace UnityEngine.Rendering.PostProcessing
             }
         }
 
+        internal static bool isValidResources()
+        {
+            return s_Resources != null;
+        }
+
         internal static void UpdateResources(PostProcessResources resources)
         {
             Destroy(s_CopyMaterial);


### PR DESCRIPTION
Fix for issue throw upon unloading a scene from AssetBundle - "Invalid pass number (1) for Graphics.Blit error" (case 1262826)